### PR TITLE
Update minor comments in pulse sim tutorial to remove confusion

### DIFF
--- a/docs/tutorials/qiskit_pulse.rst
+++ b/docs/tutorials/qiskit_pulse.rst
@@ -48,22 +48,19 @@ First, we use the pulse module in Qiskit to create a pulse schedule.
     # Sample rate of the backend in ns.
     dt = 1 / 4.5
 
-    # Define gaussian envelope function to have a pi rotation.
-    amp = 1.
-    area = 1
-    sig = area*0.399128/r/amp
+    # Define gaussian envelope function to approximately implement an sx gate.
+    amp = 1. / 1.75
+    sig = 0.6985/r/amp
     T = 4*sig
     duration = int(T / dt)
     beta = 2.0
 
-    # The 1.75 factor is used to approximately get a sx gate.
-    # Further "calibration" could be done to refine the pulse amplitude.
-    with pulse.build(name="sx-sy schedule") as xp:
-        pulse.play(pulse.Drag(duration, amp / 1.75, sig / dt, beta), pulse.DriveChannel(0))
+    with pulse.build(name="sx-sy schedule") as sxp:
+        pulse.play(pulse.Drag(duration, amp, sig / dt, beta), pulse.DriveChannel(0))
         pulse.shift_phase(np.pi/2, pulse.DriveChannel(0))
-        pulse.play(pulse.Drag(duration, amp / 1.75, sig / dt, beta), pulse.DriveChannel(0))
+        pulse.play(pulse.Drag(duration, amp, sig / dt, beta), pulse.DriveChannel(0))
 
-    xp.draw()
+    sxp.draw()
 
 
 2. Convert the pulse schedule to a :class:`.Signal`
@@ -87,7 +84,7 @@ virtual ``Z`` gate is applied.
 
     converter = InstructionToSignals(dt, carriers={"d0": w})
 
-    signals = converter.get_signals(xp)
+    signals = converter.get_signals(sxp)
     fig, axs = plt.subplots(1, 2, figsize=(14, 4.5))
     for ax, title in zip(axs, ["envelope", "signal"]):
         signals[0].draw(0, 2*T, 2000, title, axis=ax)
@@ -146,7 +143,7 @@ and in this case should produce identical behavior.
     # Start the qubit in its ground state.
     y0 = Statevector([1., 0.])
 
-    %time sol = hamiltonian_solver.solve(t_span=[0., 2*T], y0=y0, signals=xp, atol=1e-8, rtol=1e-8)
+    %time sol = hamiltonian_solver.solve(t_span=[0., 2*T], y0=y0, signals=sxp, atol=1e-8, rtol=1e-8)
 
 
 .. jupyter-execute::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The pulse simulation tutorial has a couple contradictory comments about whether some pulse parameters are meant to implement an X or SX gate. This PR makes it clear that the parameters are for an SX gate.