### PR TITLE
Add warning for JAX versions on import of Dynamics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,3 +82,7 @@ nbsphinx_timeout = 180
 nbsphinx_execute = 'always'
 nbsphinx_widgets_path = ''
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
+
+# this is tied to the temporary restriction to JAX versions <=0.4.6. See issue #190
+import os
+os.environ["JAX_JIT_PJIT_API_MERGE"] = "0"

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -20,6 +20,19 @@ try:
     from jax import Array
     from jax.core import Tracer
 
+    # warning based on JAX version
+    from packaging import version
+    import warnings
+    if version.parse(jax.__version__) >= version.parse("0.4.4"):
+        warnings.warn(
+            "The functionality in the perturbation module of Qiskit Dynamics requires a JAX "
+            "version <= 0.4.6, due to a bug in JAX versions > 0.4.6. For versions 0.4.4, 0.4.5, "
+            "and 0.4.6, using the perturbation module functionality requires setting "
+            "os.environ['JAX_JIT_PJIT_API_MERGE'] = '0' before importing JAX."
+        )
+
+
+
     JAX_TYPES = (Array, Tracer)
 
     try:

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -26,7 +26,11 @@ try:
 
     if version.parse(jax.__version__) >= version.parse("0.4.4"):
         import os
-        if version.parse(jax.__version__) > version.parse("0.4.6") or os.environ.get('JAX_JIT_PJIT_API_MERGE', None) != '0':
+
+        if (
+            version.parse(jax.__version__) > version.parse("0.4.6")
+            or os.environ.get("JAX_JIT_PJIT_API_MERGE", None) != "0"
+        ):
             warnings.warn(
                 "The functionality in the perturbation module of Qiskit Dynamics requires a JAX "
                 "version <= 0.4.6, due to a bug in JAX versions > 0.4.6. For versions 0.4.4, "

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -25,12 +25,14 @@ try:
     import warnings
 
     if version.parse(jax.__version__) >= version.parse("0.4.4"):
-        warnings.warn(
-            "The functionality in the perturbation module of Qiskit Dynamics requires a JAX "
-            "version <= 0.4.6, due to a bug in JAX versions > 0.4.6. For versions 0.4.4, 0.4.5, "
-            "and 0.4.6, using the perturbation module functionality requires setting "
-            "os.environ['JAX_JIT_PJIT_API_MERGE'] = '0' before importing JAX."
-        )
+        import os
+        if version.parse(jax.__version__) > version.parse("0.4.6") or os.environ.get('JAX_JIT_PJIT_API_MERGE', None) != '0':
+            warnings.warn(
+                "The functionality in the perturbation module of Qiskit Dynamics requires a JAX "
+                "version <= 0.4.6, due to a bug in JAX versions > 0.4.6. For versions 0.4.4, "
+                "0.4.5, and 0.4.6, using the perturbation module functionality requires setting "
+                "os.environ['JAX_JIT_PJIT_API_MERGE'] = '0' before importing JAX or Dynamics."
+            )
 
     JAX_TYPES = (Array, Tracer)
 

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -40,15 +40,6 @@ try:
 
     JAX_TYPES = (Array, Tracer)
 
-    # in versions <= 0.4.10
-    try:
-        # pylint: disable=ungrouped-imports
-        from jax.interpreters.xla import DeviceArray
-
-        JAX_TYPES += (DeviceArray,)
-    except ImportError:
-        pass
-
     from ..dispatch import Dispatch
     import numpy as np
     from .numpy import _numpy_repr
@@ -62,7 +53,7 @@ try:
     def _jax_asarray(array, dtype=None, order=None):
         """Wrapper for jax.numpy.asarray"""
         if (
-            isinstance(array, DeviceArray)
+            isinstance(array, JAX_TYPES)
             and order is None
             and (dtype is None or dtype == array.dtype)
         ):

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -25,6 +25,7 @@ try:
     try:
         # in versions <= 0.4.10
         from jax.interpreters.xla import DeviceArray
+
         JAX_TYPES += (DeviceArray,)
     except ImportError:
         pass

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -23,6 +23,7 @@ try:
     # warning based on JAX version
     from packaging import version
     import warnings
+
     if version.parse(jax.__version__) >= version.parse("0.4.4"):
         warnings.warn(
             "The functionality in the perturbation module of Qiskit Dynamics requires a JAX "
@@ -31,12 +32,11 @@ try:
             "os.environ['JAX_JIT_PJIT_API_MERGE'] = '0' before importing JAX."
         )
 
-
-
     JAX_TYPES = (Array, Tracer)
 
+    # in versions <= 0.4.10
     try:
-        # in versions <= 0.4.10
+        # pylint: disable=ungrouped-imports
         from jax.interpreters.xla import DeviceArray
 
         JAX_TYPES += (DeviceArray,)

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -17,26 +17,15 @@
 
 try:
     import jax
-    from jax.interpreters.xla import DeviceArray
+    from jax import Array
     from jax.core import Tracer
-    from jax.interpreters.ad import JVPTracer
-    from jax.interpreters.partial_eval import JaxprTracer
 
-    JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer)
+    JAX_TYPES = (Array, Tracer)
 
     try:
-        # This class was introduced in 0.4.0
-        from jax import Array
-
-        JAX_TYPES += (Array,)
-    except ImportError:
-        pass
-
-    try:
-        # This class is not in older versions of Jax
-        from jax.interpreters.partial_eval import DynamicJaxprTracer
-
-        JAX_TYPES += (DynamicJaxprTracer,)
+        # in versions <= 0.4.10
+        from jax.interpreters.xla import DeviceArray
+        JAX_TYPES += (DeviceArray,)
     except ImportError:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ requirements = [
     "multiset>=3.0.1",
 ]
 
-jax_extras = ['jax>=0.2.26, <= 0.4.6',
-              'jaxlib>=0.1.75, <= 0.4.6']
+jax_extras = ['jax>=0.4.0, <= 0.4.6',
+              'jaxlib>=0.4.0, <= 0.4.6']
 
 PACKAGES = setuptools.find_packages(exclude=['test*'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ commands = black {posargs} qiskit_dynamics test
 usedevelop = False
 deps =
     -r{toxinidir}/requirements-dev.txt
-    jax<=0.4.6
-    jaxlib<=0.4.6
+    jax<=0.4.3
+    jaxlib<=0.4.3
     diffrax
 commands =
   sphinx-build -j auto -b html -W {posargs} docs/ docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ commands = black {posargs} qiskit_dynamics test
 usedevelop = False
 deps =
     -r{toxinidir}/requirements-dev.txt
-    jax<=0.4.3
-    jaxlib<=0.4.3
+    jax<=0.4.6
+    jaxlib<=0.4.6
     diffrax
 commands =
   sphinx-build -j auto -b html -W {posargs} docs/ docs/_build/html


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #231 

This PR updates the JAX type registration in `dispatch`, and also adds a warning at JAX import time about the version bounds for JAX.

### Details and comments

The docs build has also been set to run with JAX version 0.4.3 to avoid this warning.