### PR TITLE
Add probability normalization to DynamicsBackend sampling routine

### DIFF
--- a/qiskit_dynamics/backend/backend_utils.py
+++ b/qiskit_dynamics/backend/backend_utils.py
@@ -146,7 +146,7 @@ def _get_memory_slot_probabilities(
 
 
 def _sample_probability_dict(
-    probability_dict: Dict, shots: int, seed: Optional[int] = None
+    probability_dict: Dict, shots: int, normalize_probabilities: bool = True, seed: Optional[int] = None,
 ) -> List[str]:
     """Sample outcomes based on probability dictionary.
 
@@ -154,6 +154,8 @@ def _sample_probability_dict(
         probability_dict: Dictionary representing probability distribution, with keys being
             outcomes, values being probabilities.
         shots: Number of shots.
+        normalize_probabilities: Whether or not to normalize the probabilities to sum to 1 before
+            sampling.
         seed: Seed to use in rng construction.
 
     Return:
@@ -161,6 +163,11 @@ def _sample_probability_dict(
     """
     rng = np.random.default_rng(seed=seed)
     alphabet, probs = zip(*probability_dict.items())
+
+    if normalize_probabilities:
+        probs = np.array(probs)
+        probs = probs / probs.sum()
+
     return rng.choice(alphabet, size=shots, replace=True, p=probs)
 
 

--- a/qiskit_dynamics/backend/backend_utils.py
+++ b/qiskit_dynamics/backend/backend_utils.py
@@ -146,7 +146,10 @@ def _get_memory_slot_probabilities(
 
 
 def _sample_probability_dict(
-    probability_dict: Dict, shots: int, normalize_probabilities: bool = True, seed: Optional[int] = None,
+    probability_dict: Dict,
+    shots: int,
+    normalize_probabilities: bool = True,
+    seed: Optional[int] = None,
 ) -> List[str]:
     """Sample outcomes based on probability dictionary.
 

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -118,7 +118,7 @@ class DynamicsBackend(BackendV2):
       indicating that the ground state for the system Hamiltonian should be used, or an arbitrary
       ``Statevector`` or ``DensityMatrix``. Defaults to ``"ground_state"``.
     * ``normalize_states``: Boolean indicating whether to normalize states before computing outcome
-      probabilities, and normalize probablities before sampling. Defaults to ``True``. Setting to 
+      probabilities, and normalize probablities before sampling. Defaults to ``True``. Setting to
       ``False`` can result in errors if the solution tolerance results in probabilities with
       significant numerical deviation from a proper probability distribution.
     * ``meas_level``: Form of measurement output. Supported values are ``1`` and ``2``. ``1``
@@ -819,7 +819,10 @@ def default_experiment_result_function(
 
         # sample
         memory_samples = _sample_probability_dict(
-            memory_slot_probabilities, shots=backend.options.shots, normalize_probabilities=backend.options.normalize_states, seed=seed
+            memory_slot_probabilities,
+            shots=backend.options.shots,
+            normalize_probabilities=backend.options.normalize_states,
+            seed=seed,
         )
         counts = _get_counts_from_samples(memory_samples)
 

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -118,9 +118,9 @@ class DynamicsBackend(BackendV2):
       indicating that the ground state for the system Hamiltonian should be used, or an arbitrary
       ``Statevector`` or ``DensityMatrix``. Defaults to ``"ground_state"``.
     * ``normalize_states``: Boolean indicating whether to normalize states before computing outcome
-      probabilities. Defaults to ``True``. Setting to ``False`` can result in errors if the solution
-      tolerance results in probabilities with significant numerical deviation from a proper
-      probability distribution.
+      probabilities, and normalize probablities before sampling. Defaults to ``True``. Setting to 
+      ``False`` can result in errors if the solution tolerance results in probabilities with
+      significant numerical deviation from a proper probability distribution.
     * ``meas_level``: Form of measurement output. Supported values are ``1`` and ``2``. ``1``
       returns IQ points and ``2`` returns counts. Defaults to ``meas_level == 2``.
     * ``meas_return``: Level of measurement data to return. For ``meas_level = 1`` ``"single"``
@@ -785,7 +785,7 @@ def default_experiment_result_function(
 
     yf = solver_result.y[-1]
     tf = solver_result.t[-1]
-
+    print(yf.trace())
     # Take state out of frame, put in dressed basis, and normalize
     if isinstance(yf, Statevector):
         yf = np.array(backend.options.solver.model.rotating_frame.state_out_of_frame(t=tf, y=yf))
@@ -819,7 +819,7 @@ def default_experiment_result_function(
 
         # sample
         memory_samples = _sample_probability_dict(
-            memory_slot_probabilities, shots=backend.options.shots, seed=seed
+            memory_slot_probabilities, shots=backend.options.shots, normalize_probabilities=backend.options.normalize_states, seed=seed
         )
         counts = _get_counts_from_samples(memory_samples)
 

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -785,7 +785,7 @@ def default_experiment_result_function(
 
     yf = solver_result.y[-1]
     tf = solver_result.t[-1]
-    print(yf.trace())
+
     # Take state out of frame, put in dressed basis, and normalize
     if isinstance(yf, Statevector):
         yf = np.array(backend.options.solver.model.rotating_frame.state_out_of_frame(t=tf, y=yf))

--- a/releasenotes/notes/normalize-probabilities-d729245bb3fe5f10.yaml
+++ b/releasenotes/notes/normalize-probabilities-d729245bb3fe5f10.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ``DynamicsBackend.options.normalize_states`` now also controls whether or not the probability
+    distribution over outcomes is normalized before sampling outcomes. 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #237

### Details and comments

When looking at the implementation I realized that two normalizations are necessary; it isn't possible to only normalize the probability before sampling. The state needs to be normalized before calculating probabilities so that the `QuantumState.probabilities_dict` function doesn't raise an error, and the resultant probabilities need to then be normalized to avoid numerical error in the probability computation. 

As a result of this, I've kept `options.normalize_states`, and modified the code that samples the outcomes to also normalize the probabilities if `options.normalize_states == True`. I've modified the description of the `normalize_states` option to describe this, and added a "fixes" release note for this.
