### PR TITLE
Add warning if digital carrier exceeds Nyquist frequency in pulse -> signal conversion

### DIFF
--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -139,7 +139,7 @@ class InstructionToSignals:
           :math:`\Delta\nu \mapsto \mu - \nu`, where :math:`\nu` is the analog carrier frequency.
           Similarly to ``ShiftFrequency``, the shift rule for :math:`\phi_a` is defined to maintain
           carrier wave continuity.
-        
+
         If, at any sample point :math:`k`, :math:`\Delta\nu(k)` is larger than the Nyquist sampling
         rate given by ``dt``, a warning will be raised.
 
@@ -200,7 +200,7 @@ class InstructionToSignals:
 
             if isinstance(inst, SetPhase):
                 phases[chan] = inst.phase
-            
+
             if isinstance(inst, ShiftFrequency):
                 frequency_shifts[chan] = frequency_shifts[chan] + Array(inst.frequency)
                 phase_accumulations[chan] = (
@@ -384,7 +384,9 @@ def _lru_cache_expr(expr: sym.Expr, backend) -> Callable:
 def _nyquist_warn(frequency_shift: Array, dt: float, channel: str):
     """Raise a warning if the frequency shift is above the Nyquist frequency given by ``dt``."""
 
-    if (Array(frequency_shift).backend != "jax" or not isinstance(jnp.array(0), jax.core.Tracer)) and np.abs(frequency_shift) > 0.5 / dt:
+    if (
+        Array(frequency_shift).backend != "jax" or not isinstance(jnp.array(0), jax.core.Tracer)
+    ) and np.abs(frequency_shift) > 0.5 / dt:
         warn(
             "Due to SetFrequency and ShiftFrequency instructions, there is a frequency deviation "
             f"from the analog carrier frequency of channel {channel} larger than the Nyquist "

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -41,6 +41,12 @@ from qiskit import QiskitError
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.signals import DiscreteSignal
 
+try:
+    import jax
+    import jax.numpy as jnp
+except ImportError:
+    pass
+
 
 class InstructionToSignals:
     """Converts pulse instructions to signals to be used in models.
@@ -372,10 +378,10 @@ def _lru_cache_expr(expr: sym.Expr, backend) -> Callable:
     return sym.lambdify(params, expr, modules=backend)
 
 
-def _nyquist_warn(frequency_shift: float, dt: float, channel: str):
+def _nyquist_warn(frequency_shift: Array, dt: float, channel: str):
     """Raise a warning if the frequency shift is above the Nyquist frequency given by ``dt``."""
 
-    if np.abs(frequency_shift) > 0.5 / dt:
+    if (Array(frequency_shift).backend != "jax" or not isinstance(jnp.array(0), jax.core.Tracer)) and np.abs(frequency_shift) > 0.5 / dt:
         warn(
             "Due to SetFrequency and ShiftFrequency instructions, there is a frequency deviation "
             f"from the analog carrier frequency of channel {channel} larger than the Nyquist "

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -139,6 +139,9 @@ class InstructionToSignals:
           :math:`\Delta\nu \mapsto \mu - \nu`, where :math:`\nu` is the analog carrier frequency.
           Similarly to ``ShiftFrequency``, the shift rule for :math:`\phi_a` is defined to maintain
           carrier wave continuity.
+        
+        If, at any sample point :math:`k`, :math:`\Delta\nu(k)` is larger than the Nyquist sampling
+        rate given by ``dt``, a warning will be raised.
 
         Args:
             schedule: The schedule to represent in terms of signals. Instances of

--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -38,13 +38,13 @@ class TestPulseToSignals(QiskitDynamicsTestCase):
         super().setUp()
         # Typical length of samples in units of dt in IBM real backends is 1/4.5.
         self._dt = 1 / 4.5
-    
+
     def test_nyquist_warning(self):
         """Test Nyquist warning is raised."""
-        converter = InstructionToSignals(dt=1, carriers={"d0": 0.})
+        converter = InstructionToSignals(dt=1, carriers={"d0": 0.0})
 
         sched = Schedule(name="Schedule")
-        sched += pulse.SetFrequency(1., pulse.DriveChannel(0))
+        sched += pulse.SetFrequency(1.0, pulse.DriveChannel(0))
         sched += pulse.Play(
             pulse.Drag(duration=20, amp=0.5, sigma=4, beta=0.5), pulse.DriveChannel(0)
         )

--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -38,6 +38,19 @@ class TestPulseToSignals(QiskitDynamicsTestCase):
         super().setUp()
         # Typical length of samples in units of dt in IBM real backends is 1/4.5.
         self._dt = 1 / 4.5
+    
+    def test_nyquist_warning(self):
+        """Test Nyquist warning is raised."""
+        converter = InstructionToSignals(dt=1, carriers={"d0": 0.})
+
+        sched = Schedule(name="Schedule")
+        sched += pulse.SetFrequency(1., pulse.DriveChannel(0))
+        sched += pulse.Play(
+            pulse.Drag(duration=20, amp=0.5, sigma=4, beta=0.5), pulse.DriveChannel(0)
+        )
+
+        with self.assertWarnsRegex(Warning, "Due to SetFrequency and ShiftFrequency"):
+            converter.get_signals(sched)
 
     def test_pulse_to_signals(self):
         """Generic test."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #241

A warning is added to the pulse -> signal converter if the digital carrier frequency (resulting from `SetFrequency` and `ShiftFrequency` instructions) exceeds the Nyquist frequency set by the sample size `dt`.

### Details and comments

The warning is suppressed if the conversion is called within JAX tracing, as in this case the boolean function `np.abs(frequency_shift) > 0.5 / dt` cannot be evaluated.

A test has been added, and @nkanazawa1989 I've verified that the warning is raised in your example that motivated this PR.