### PR TITLE
Fix bug with carrier_freq being a JAX tracer if envelope is constant in Signal

### DIFF
--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -26,7 +26,6 @@ from matplotlib import pyplot as plt
 
 try:
     import jax.numpy as jnp
-    import jax
 except ImportError:
     pass
 
@@ -96,12 +95,12 @@ class Signal:
             envelope = Array(complex(envelope))
 
         if isinstance(envelope, Array):
-
             # if envelope is constant and the carrier is zero, this is a constant signal
             try:
+                # try block is for catching JAX tracer errors
                 if carrier_freq == 0.0:
                     self._is_constant = True
-            except:
+            except Exception:  # pylint: disable=broad-except
                 pass
 
             if envelope.backend == "jax":

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -96,16 +96,13 @@ class Signal:
             envelope = Array(complex(envelope))
 
         if isinstance(envelope, Array):
-            carrier_freq = Array(carrier_freq)
 
             # if envelope is constant and the carrier is zero, this is a constant signal
-            if (
-                not (
-                    carrier_freq.backend == "jax" and isinstance(carrier_freq.data, jax.core.Tracer)
-                )
-                and carrier_freq == 0.0
-            ):
-                self._is_constant = True
+            try:
+                if carrier_freq == 0.0:
+                    self._is_constant = True
+            except:
+                pass
 
             if envelope.backend == "jax":
                 self._envelope = lambda t: envelope * jnp.ones_like(Array(t).data)

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -26,6 +26,7 @@ from matplotlib import pyplot as plt
 
 try:
     import jax.numpy as jnp
+    import jax
 except ImportError:
     pass
 
@@ -95,8 +96,15 @@ class Signal:
             envelope = Array(complex(envelope))
 
         if isinstance(envelope, Array):
+            carrier_freq = Array(carrier_freq)
+
             # if envelope is constant and the carrier is zero, this is a constant signal
-            if carrier_freq == 0.0:
+            if (
+                not (
+                    carrier_freq.backend == "jax" and isinstance(carrier_freq.data, jax.core.Tracer)
+                )
+                and carrier_freq == 0.0
+            ):
                 self._is_constant = True
 
             if envelope.backend == "jax":

--- a/releasenotes/notes/carrier-freq-0-19ad4362c874944f.yaml
+++ b/releasenotes/notes/carrier-freq-0-19ad4362c874944f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    In the case that ``envelope`` is a constant, the :meth:`Signal.__init__` method has been updated
+    to not attempt to evaluate ``carrier_freq == 0.0`` if ``carrier_freq`` is a JAX tracer. In this
+    case, it is not possible to determine if the :class:`Signal` instance is constant. This resolves
+    an error that was being raised during JAX tracing if ``carrier_freq`` is abstract.

--- a/test/dynamics/signals/test_signals.py
+++ b/test/dynamics/signals/test_signals.py
@@ -933,6 +933,22 @@ class TestSignalsJaxTransformations(QiskitDynamicsTestCase, TestJaxBase):
         jit_grad_eval = jit(grad(eval_const))
         self.assertAllClose(jit_grad_eval(3.0), 1.0)
 
+    def test_jit_grad_carrier_freq_construct(self):
+        """Test jit/gradding through a function that constructs a signal and takes carrier frequency
+        as an argument.
+        """
+
+        def eval_sig(a, v, t):
+            a = Array(a)
+            v = Array(v)
+            return Array(Signal(a, v)(t)).data
+
+        jit_eval = jit(eval_sig)
+        self.assertAllClose(jit_eval(1.0, 1.0, 1.0), 1.0)
+
+        jit_grad_eval = jit(grad(eval_sig))
+        self.assertAllClose(jit_grad_eval(1.0, 1.0, 1.0), 1.0)
+
     def test_signal_list_jit_eval(self):
         """Test jit-compilation of SignalList evaluation."""
         call_jit = jit(lambda t: Array(self.signal_list(t)).data)

--- a/test/dynamics/signals/test_signals.py
+++ b/test/dynamics/signals/test_signals.py
@@ -933,6 +933,19 @@ class TestSignalsJaxTransformations(QiskitDynamicsTestCase, TestJaxBase):
         jit_grad_eval = jit(grad(eval_const))
         self.assertAllClose(jit_grad_eval(3.0), 1.0)
 
+        # validate that is_constant is being properly set
+        def eval_const_conditional(a):
+            a = Array(a)
+            sig = Signal(a)
+
+            if sig.is_constant:
+                return 5.0
+            else:
+                return 3.0
+
+        jit_eval = jit(eval_const_conditional)
+        self.assertAllClose(jit_eval(1.0), 5.0)
+
     def test_jit_grad_carrier_freq_construct(self):
         """Test jit/gradding through a function that constructs a signal and takes carrier frequency
         as an argument.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #245

### Details and comments

I ended up putting the `carrier_freq == 0.0` check into a `try` block to solve this. It's not the prettiest solution, but it seemed to be the simplest and most concise. I originally had checks for JAX types, then checked if `carrier_freq` was a tracer, but it was actually awkward to implement this.

The current code is essentially equivalent to:
- if `carrier_freq` is not a JAX tracer object (or a tracer object inside of an `Array`), and `carrier_freq == 0.0` then set `self._is_constant = True`.

The awkwardness with directly implementing this is that the code also needs to work if JAX isn't installed, so the "if `carrier_freq` is not a JAX tracer object" is itself an awkward thing to check.

I've also added tests verifying the original issue is resolved: 
- A check that `carrier_freq` can be properly traced within a JAX function if the envelope is constant.
- A modification to an existing test to verify that `is_constant` is properly set within JAX tracing if `carrier_freq` is concretely `0`.