### PR TITLE
Remove subsystem_labels option from DynamicsBackend

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -693,7 +693,7 @@ class DynamicsBackend(BackendV2):
         # can add the 
         subsystem_dims = [subsystem_dims_dict.get(idx, 1) for idx in range(backend_num_qubits)]
         ##############################################################################################
-        import pdb; pdb.set_trace()
+
         # construct model frequencies dictionary from backend
         channel_freqs = _get_backend_channel_freqs(
             backend_target=backend_target,

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -185,7 +185,7 @@ class DynamicsBackend(BackendV2):
 
         # Set simulator options
         self.set_options(solver=solver, **options)
-            
+
         if self.options.meas_map is None:
             meas_map = [[idx] for idx in range(len(self.options.subsystem_dims))]
             self.set_options(meas_map=meas_map)
@@ -482,9 +482,7 @@ class DynamicsBackend(BackendV2):
         if qubit < len(self.options.subsystem_dims):
             return ChannelClass(qubit)
 
-        raise QiskitError(
-            f"{method_name} requested for qubit {qubit}, which is out of bounds."
-        )
+        raise QiskitError(f"{method_name} requested for qubit {qubit}, which is out of bounds.")
 
     def drive_channel(self, qubit: int) -> pulse.DriveChannel:
         """Return the drive channel for a given qubit."""
@@ -668,10 +666,7 @@ class DynamicsBackend(BackendV2):
             hamiltonian_channels,
             subsystem_dims_dict,
         ) = parse_backend_hamiltonian_dict(backend_config.hamiltonian, subsystem_list)
-        ##############################################################################################
-        #subsystem_dims = [subsystem_dims[idx] for idx in subsystem_list]
         subsystem_dims = [subsystem_dims_dict.get(idx, 1) for idx in range(backend_num_qubits)]
-        ##############################################################################################
 
         # construct model frequencies dictionary from backend
         channel_freqs = _get_backend_channel_freqs(

--- a/releasenotes/notes/subsystem_labels-removal-9fcc71c310eff220.yaml
+++ b/releasenotes/notes/subsystem_labels-removal-9fcc71c310eff220.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    The ``subsystem_labels`` option has been removed from the :class:`.DynamicsBackend`. This
+    removal impacts some technical aspects of the backend returned by
+    :meth:`.DynamicsBackend.from_backend` when the ``subsystem_list`` argument is used. Using the
+    ``subsystem_list`` argument with :meth:`.DynamicsBackend.from_backend` restricts the internally
+    constructed model to the qubits in ``subsystem_list``. When doing so previously, the option
+    ``subsystem_labels`` would be set to ``subsystem_labels``, and ``subsystem_dims`` would record
+    only the dimensions for the systems in ``subsystem_labels``. To account for the fact that
+    ``subsystem_labels`` no longer exists, :meth:`.DynamicsBackend.from_backend` now constructs
+    ``subsystem_dims`` to list a dimension for all of the qubits in the original backend, however
+    now the dimensions of the removed systems are given as 1 (i.e. they are treated as trivial
+    quantum systems with a single state). This change is made only for technical bookkeping
+    purposes, and has no impact on the core simulation behaviour.

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -129,7 +129,7 @@ class TestDynamicsBackendValidation(QiskitDynamicsTestCase):
 
         with self.assertRaisesRegex(QiskitError, "Attempted to measure out of bounds subsystem 1."):
             self.simple_backend.run(schedule)
-    
+
     def test_measure_trivial_subsystem(self):
         """Attempt to measure subsystem with dimension 1."""
 

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -127,7 +127,18 @@ class TestDynamicsBackendValidation(QiskitDynamicsTestCase):
             pulse.play(pulse.Waveform([0.5, 0.5, 0.5]), pulse.DriveChannel(0))
             pulse.acquire(duration=1, qubit_or_channel=1, register=pulse.MemorySlot(0))
 
-        with self.assertRaisesRegex(QiskitError, "Attempted to measure subsystem 1"):
+        with self.assertRaisesRegex(QiskitError, "Attempted to measure out of bounds subsystem 1."):
+            self.simple_backend.run(schedule)
+    
+    def test_measure_trivial_subsystem(self):
+        """Attempt to measure subsystem with dimension 1."""
+
+        with pulse.build() as schedule:
+            pulse.play(pulse.Waveform([0.5, 0.5, 0.5]), pulse.DriveChannel(0))
+            pulse.acquire(duration=1, qubit_or_channel=1, register=pulse.MemorySlot(0))
+
+        self.simple_backend.set_options(subsystem_dims=[2, 1])
+        with self.assertWarnsRegex(Warning, "Measuring trivial subsystem 1"):
             self.simple_backend.run(schedule)
 
     def test_invalid_initial_state(self):
@@ -327,19 +338,6 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
 
         counts = self.iq_to_counts(result.get_memory())
         self.assertDictEqual(counts, {"0": 510, "1": 514})
-
-    def test_pi_half_pulse_relabelled(self):
-        """Test simulation of a pi/2 pulse with qubit relabelled."""
-
-        self.simple_backend.set_options(subsystem_labels=[1])
-
-        with pulse.build() as schedule:
-            with pulse.align_right():
-                pulse.play(pulse.Waveform([1.0] * 50), pulse.DriveChannel(0))
-                pulse.acquire(duration=1, qubit_or_channel=1, register=pulse.MemorySlot(1))
-
-        result = self.simple_backend.run(schedule, seed_simulator=398472).result()
-        self.assertDictEqual(result.get_counts(), {"00": 513, "10": 511})
 
     def test_circuit_with_pulse_defs(self):
         """Test simulating a circuit with pulse definitions."""
@@ -1128,7 +1126,7 @@ class Test_get_acquire_instruction_timings(QiskitDynamicsTestCase):
             measurement_subsystems_list,
             memory_slot_indices_list,
         ) = _get_acquire_instruction_timings(
-            schedules=[schedule0, schedule1], valid_subsystem_labels=[0, 1], dt=dt
+            schedules=[schedule0, schedule1], subsystem_dims=[2, 2], dt=dt
         )
 
         self.assertAllClose(np.array(t_span), np.array([[0.0, 104 * dt], [0.0, 100 * dt]]))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #235

### Details and comments (out of date, see next comment)

This is currently a draft to prototype a potential solution to #235, in which the `subsystem_labels` option is removed, and all qubits removed via the `subsystem_list` argument of `from_backend` are actually "kept" as trivial 1-dimensional systems.

So far:
- I've commented out all lines/blocks using `subsystem_labels`.
- Where necessary, new code has been added, e.g. construction of `subsystem_dims` in `from_backend` has been changed to include all pre-existing subsystems, but setting the dimension of the "removed" subsystems to `1` (instead of not including them at all).

Initial testing in a jupyter notebook seems to indicate that this behaves as expected:
- I can do `from_backend` with a non-trivial `subsystem_list`, and the backend is built without issue.
- I haven't yet done any verifications of correctness, but it seems like we can run sims and compute measurement results as well.

To do:
- Add number of qubits to the backend wherever it makes sense.
- Do some initial verification that the calculations are correct.
- The `subsystem_labels` option was used to raise errors of non-existent subsystems were measured. As this no longer exists, it would be nice to still warn users if their schedule measures a trivial subsystem. 
    - This could just be done by checking the dimension of the measured subsystem.
- Pre-existing tests need to be modified.

Question:
- This will remove the `subsystem_labels` option. I'm not sure how this could be deprecated, because it will literally serve no purpose and have no effect anymore.