### PR TITLE
Drop support for backendV2 in from_backend and _to_schedule_list

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -544,7 +544,7 @@ class DynamicsBackend(BackendV2):
     @classmethod
     def from_backend(
         cls,
-        backend: Union[BackendV1, BackendV2],
+        backend: BackendV1,
         subsystem_list: Optional[List[int]] = None,
         rotating_frame: Optional[Union[Array, RotatingFrame, str]] = "auto",
         evaluation_mode: str = "dense",
@@ -958,7 +958,7 @@ def _get_acquire_instruction_timings(
 
 
 def _to_schedule_list(
-    run_input: List[Union[QuantumCircuit, Schedule, ScheduleBlock]], backend: BackendV2
+    run_input: List[Union[QuantumCircuit, Schedule, ScheduleBlock]], backend: BackendV1
 ):
     """Convert all inputs to schedules, and store the number of classical registers present
     in any circuits.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
closes https://github.com/Qiskit-Extensions/qiskit-dynamics/issues/236.


### Details and comments
The type hint of an argument `backend` in `from_backend` supports both backendV1 and backendV2. However, we found it confuses people because almost all backendV2 cannot be used for dynamics backend in reality.
 
In addition, I changed the type hint of an argument `backend` from `BackendV2` to `BackendV1` in `_to_schedule_list`. In `_to_schedule_list`, `build_schedule` is used. Scheduling with backendV2 fails because of some bugs in terra. I am assigned to work on it but cannot solve it yet.

In the future, supporting `BackendV2` again in these functions is essential for users.
