### PR TITLE
Fix citation of JuliaQuantumControl

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -173,7 +173,8 @@
 }
 
 @misc{julia_qc,
-  title = {A Julia Framework for Quantum Optimal Control},
+  author = {Goerz, Michael H. and Carrasco, Sebastián C. and Malinovsky, Vladimir S. and {Contributors}},
+  title = {A {Julia} Framework for Quantum Optimal Control},
   year = {2023},
   publisher = {GitHub},
   journal = {GitHub repository},


### PR DESCRIPTION
As the author of the QuantumControl.jl package, I would prefer if you would cite it in the JOSS paper with the names of the people involved in the project.

