### PR TITLE
Fix maxOS CI test failures

### DIFF
--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -1025,14 +1025,23 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
         sig = Signal(0.9, carrier_freq=5.0)
 
         res_pulse = ham_pulse_solver.solve(
-            t_span=[0, 0.4], y0=Statevector([0.0, 1.0]), signals=schedule, method=self.method
+            t_span=[0, 0.4],
+            y0=Statevector([0.0, 1.0]),
+            signals=schedule,
+            method=self.method,
+            atol=1e-12,
+            rtol=1e-12,
         )
         res_signal = ham_solver.solve(
-            t_span=[0, 0.4], y0=Statevector([0.0, 1.0]), signals=[sig], method=self.method
+            t_span=[0, 0.4],
+            y0=Statevector([0.0, 1.0]),
+            signals=[sig],
+            method=self.method,
+            atol=1e-12,
+            rtol=1e-12,
         )
 
-        self.assertAllClose(res_pulse.t, res_signal.t, atol=1e-14, rtol=1e-14)
-        self.assertAllClose(res_pulse.y, res_signal.y, atol=1e-14, rtol=1e-14)
+        self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-10, rtol=1e-10)
 
     def test_rwa_lindblad_solver(self):
         """Test RWA for pulse solver with Lindblad information."""
@@ -1081,8 +1090,7 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             rtol=1e-12,
         )
 
-        self.assertAllClose(res_pulse.t, res_signal.t, atol=1e-12, rtol=1e-12)
-        self.assertAllClose(res_pulse.y, res_signal.y, atol=1e-12, rtol=1e-12)
+        self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-10, rtol=1e-10)
 
     def test_list_simulation_mixing_types(self):
         """Test correct formatting when input states have the same shape.

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -414,7 +414,9 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.0]
         signals = ([Signal(1.0, carrier_freq=5.0)], [Signal(1.0, carrier_freq=5.0)])
 
-        res1 = rwa_td_lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals)
+        res1 = rwa_td_lindblad_solver.solve(
+            t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12
+        )
 
         self.td_lindblad_model.signals = signals
         rwa_td_lindblad_model = rotating_wave_approximation(self.td_lindblad_model, cutoff_freq=5.0)
@@ -422,7 +424,7 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
             generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
         )
 
-        self.assertAllClose(res1.y, res2.y)
+        self.assertAllClose(res1.y[-1], res2.y[-1])
 
     def test_signals_are_None(self):
         """Test the model signals return to being None after simulation."""

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -296,10 +296,10 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.42]
         signals = [Signal(3.0)]
 
-        res1 = ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10)
+        res1 = ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11)
 
         self.ham_model.signals = signals
-        res2 = solve_lmde(generator=self.ham_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1 - 10)
+        res2 = solve_lmde(generator=self.ham_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11)
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
@@ -317,11 +317,11 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.42]
         signals = [Signal(3.0)]
 
-        res1 = lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10)
+        res1 = lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11)
 
         self.lindblad_model.signals = (signals, None)
         res2 = solve_lmde(
-            generator=self.lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+            generator=self.lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -342,12 +342,12 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = ([Signal(3.0)], [Signal(2.0)])
 
         res1 = td_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10
+            t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11
         )
 
         self.td_lindblad_model.signals = signals
         res2 = solve_lmde(
-            generator=self.td_lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+            generator=self.td_lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -367,11 +367,11 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.0]
         signals = [Signal(1.0, carrier_freq=5.0)]
 
-        res1 = rwa_ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10)
+        res1 = rwa_ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11)
 
         self.ham_model.signals = signals
         rwa_ham_model = rotating_wave_approximation(self.ham_model, cutoff_freq=5.0)
-        res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10)
+        res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11)
 
         self.assertAllClose(res1.y, res2.y, atol=1e-8, rtol=1e-8)
 
@@ -394,13 +394,13 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = [Signal(1.0, carrier_freq=5.0)]
 
         res1 = rwa_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10
+            t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11
         )
 
         self.lindblad_model.signals = (signals, None)
         rwa_lindblad_model = rotating_wave_approximation(self.lindblad_model, cutoff_freq=5.0)
         res2 = solve_lmde(
-            generator=rwa_lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+            generator=rwa_lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -425,13 +425,13 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = ([Signal(1.0, carrier_freq=5.0)], [Signal(1.0, carrier_freq=5.0)])
 
         res1 = rwa_td_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10
+            t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11
         )
 
         self.td_lindblad_model.signals = signals
         rwa_td_lindblad_model = rotating_wave_approximation(self.td_lindblad_model, cutoff_freq=5.0)
         res2 = solve_lmde(
-            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -831,8 +831,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=sched,
             signals=None,
             test_tol=1e-8,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
     @unpack
@@ -860,8 +860,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=sched,
             signals=[sig],
             test_tol=1e-8,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
     @unpack
@@ -1047,16 +1047,16 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=Statevector([0.0, 1.0]),
             signals=schedule,
             method=self.method,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
         res_signal = ham_solver.solve(
             t_span=[0, 0.4],
             y0=Statevector([0.0, 1.0]),
             signals=[sig],
             method=self.method,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
         self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-8, rtol=1e-8)
@@ -1095,8 +1095,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             signals=schedule,
             method=self.method,
             convert_results=False,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
         res_signal = lindblad_solver.solve(
             t_span=[0, 0.4],
@@ -1104,8 +1104,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             signals=[sig],
             method=self.method,
             convert_results=False,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
         self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-8, rtol=1e-8)
@@ -1160,8 +1160,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=[sched0, sched1],
             signals=signals,
             test_tol=1e-8,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
     def test_channel_without_instructions(self):
@@ -1184,8 +1184,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=sched,
             signals=signals,
             test_tol=1e-8,
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
     def _compare_schedule_to_signals(

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -296,12 +296,12 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.42]
         signals = [Signal(3.0)]
 
-        res1 = ham_solver.solve(t_span=t_span, y0=y0, signals=signals)
+        res1 = ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10)
 
         self.ham_model.signals = signals
-        res2 = solve_lmde(generator=self.ham_model, t_span=t_span, y0=y0)
+        res2 = solve_lmde(generator=self.ham_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1 - 10)
 
-        self.assertAllClose(res1.y, res2.y)
+        self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_lindblad_model(self):
         """Test for solver with only static lindblad information."""
@@ -317,12 +317,14 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.42]
         signals = [Signal(3.0)]
 
-        res1 = lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals)
+        res1 = lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10)
 
         self.lindblad_model.signals = (signals, None)
-        res2 = solve_lmde(generator=self.lindblad_model, t_span=t_span, y0=y0)
+        res2 = solve_lmde(
+            generator=self.lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+        )
 
-        self.assertAllClose(res1.y, res2.y)
+        self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_td_lindblad_model(self):
         """Test for solver with time-dependent lindblad information."""
@@ -339,12 +341,16 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.42]
         signals = ([Signal(3.0)], [Signal(2.0)])
 
-        res1 = td_lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals)
+        res1 = td_lindblad_solver.solve(
+            t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10
+        )
 
         self.td_lindblad_model.signals = signals
-        res2 = solve_lmde(generator=self.td_lindblad_model, t_span=t_span, y0=y0)
+        res2 = solve_lmde(
+            generator=self.td_lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+        )
 
-        self.assertAllClose(res1.y, res2.y)
+        self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_rwa_ham_model(self):
         """Test correct handling of RWA for a Hamiltonian model."""
@@ -361,13 +367,13 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.0]
         signals = [Signal(1.0, carrier_freq=5.0)]
 
-        res1 = rwa_ham_solver.solve(t_span=t_span, y0=y0, signals=signals)
+        res1 = rwa_ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10)
 
         self.ham_model.signals = signals
         rwa_ham_model = rotating_wave_approximation(self.ham_model, cutoff_freq=5.0)
-        res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0)
+        res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10)
 
-        self.assertAllClose(res1.y, res2.y)
+        self.assertAllClose(res1.y, res2.y, atol=1e-8, rtol=1e-8)
 
     def test_rwa_lindblad_model(self):
         """Test correct handling of RWA for Lindblad model without
@@ -387,13 +393,17 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.0]
         signals = [Signal(1.0, carrier_freq=5.0)]
 
-        res1 = rwa_lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals)
+        res1 = rwa_lindblad_solver.solve(
+            t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10
+        )
 
         self.lindblad_model.signals = (signals, None)
         rwa_lindblad_model = rotating_wave_approximation(self.lindblad_model, cutoff_freq=5.0)
-        res2 = solve_lmde(generator=rwa_lindblad_model, t_span=t_span, y0=y0)
+        res2 = solve_lmde(
+            generator=rwa_lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
+        )
 
-        self.assertAllClose(res1.y, res2.y)
+        self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_rwa_td_lindblad_model(self):
         """Test correct handling of RWA for Lindblad model with
@@ -415,16 +425,16 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = ([Signal(1.0, carrier_freq=5.0)], [Signal(1.0, carrier_freq=5.0)])
 
         res1 = rwa_td_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12
+            t_span=t_span, y0=y0, signals=signals, atol=1e-10, rtol=1e-10
         )
 
         self.td_lindblad_model.signals = signals
         rwa_td_lindblad_model = rotating_wave_approximation(self.td_lindblad_model, cutoff_freq=5.0)
         res2 = solve_lmde(
-            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
+            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-10, rtol=1e-10
         )
 
-        self.assertAllClose(res1.y[-1], res2.y[-1])
+        self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_signals_are_None(self):
         """Test the model signals return to being None after simulation."""
@@ -558,15 +568,19 @@ class TestSolverSimulation(QiskitDynamicsTestCase):
             y0=Statevector([0.0, 1.0]),
             signals=[Signal(1.0, 5.0)],
             method=self.method,
+            atol=1e-12,
+            rtol=1e-12,
         )
         results2 = self.lindblad_solver.solve(
             t_span=[0.0, 1.0],
             y0=Statevector([0.0, 1.0]),
             signals=[Signal(1.0, 5.0)],
             method=self.method,
+            atol=1e-12,
+            rtol=1e-12,
         )
         self.assertTrue(isinstance(results.y[-1], DensityMatrix))
-        self.assertAllClose(results.y[-1].data, results2.y[-1].data)
+        self.assertAllClose(results.y[-1].data, results2.y[-1].data, atol=1e-10, rtol=1e-10)
 
     def test_array_vectorized_lindblad(self):
         """Test Lindblad solver is array-vectorized."""
@@ -649,7 +663,7 @@ class TestSolverSimulation(QiskitDynamicsTestCase):
             atol=1e-10,
             rtol=1e-10,
         )
-        self.assertAllClose(results.y[-1].data, results2.y[-1].data)
+        self.assertAllClose(results.y[-1].data, results2.y[-1].data, atol=1e-8, rtol=1e-8)
 
     def test_lindblad_solver_consistency(self):
         """Test consistency of lindblad solver with dissipators specified
@@ -816,9 +830,9 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=Statevector([0.0, 1.0]),
             schedules=sched,
             signals=None,
-            test_tol=1e-9,
-            atol=1e-12,
-            rtol=1e-12,
+            test_tol=1e-8,
+            atol=1e-10,
+            rtol=1e-10,
         )
 
     @unpack
@@ -845,9 +859,9 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=Statevector([1.0, 0.0]),
             schedules=sched,
             signals=[sig],
-            test_tol=1e-9,
-            atol=1e-12,
-            rtol=1e-12,
+            test_tol=1e-8,
+            atol=1e-10,
+            rtol=1e-10,
         )
 
     @unpack
@@ -903,7 +917,7 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=[Statevector([1.0, 0.0]), DensityMatrix([0.0, 1.0])],
             schedules=[sched0, sched1],
             signals=signals,
-            test_tol=1e-9,
+            test_tol=1e-8,
             atol=1e-12,
             rtol=1e-12,
         )
@@ -943,8 +957,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=sched,
             signals=signals,
             test_tol=1e-8,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
     def test_4_channel_schedule(self):
@@ -997,9 +1011,9 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=Statevector([1.0, 0.0]),
             schedules=schedule,
             signals=signals,
-            test_tol=1e-9,
-            atol=1e-13,
-            rtol=1e-13,
+            test_tol=1e-8,
+            atol=1e-11,
+            rtol=1e-11,
         )
 
     def test_rwa_ham_solver(self):
@@ -1033,19 +1047,19 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=Statevector([0.0, 1.0]),
             signals=schedule,
             method=self.method,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-10,
+            rtol=1e-10,
         )
         res_signal = ham_solver.solve(
             t_span=[0, 0.4],
             y0=Statevector([0.0, 1.0]),
             signals=[sig],
             method=self.method,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-10,
+            rtol=1e-10,
         )
 
-        self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-10, rtol=1e-10)
+        self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_rwa_lindblad_solver(self):
         """Test RWA for pulse solver with Lindblad information."""
@@ -1081,8 +1095,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             signals=schedule,
             method=self.method,
             convert_results=False,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-10,
+            rtol=1e-10,
         )
         res_signal = lindblad_solver.solve(
             t_span=[0, 0.4],
@@ -1090,11 +1104,11 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             signals=[sig],
             method=self.method,
             convert_results=False,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-10,
+            rtol=1e-10,
         )
 
-        self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-10, rtol=1e-10)
+        self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_list_simulation_mixing_types(self):
         """Test correct formatting when input states have the same shape.
@@ -1146,8 +1160,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=[sched0, sched1],
             signals=signals,
             test_tol=1e-8,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-10,
+            rtol=1e-10,
         )
 
     def test_channel_without_instructions(self):
@@ -1170,8 +1184,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=sched,
             signals=signals,
             test_tol=1e-8,
-            atol=1e-12,
-            rtol=1e-12,
+            atol=1e-10,
+            rtol=1e-10,
         )
 
     def _compare_schedule_to_signals(

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -373,7 +373,7 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         rwa_ham_model = rotating_wave_approximation(self.ham_model, cutoff_freq=5.0)
         res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12)
 
-        self.assertAllClose(res1.y, res2.y, atol=1e-8, rtol=1e-8)
+        self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
 
     def test_rwa_lindblad_model(self):
         """Test correct handling of RWA for Lindblad model without

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -1081,8 +1081,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             rtol=1e-12,
         )
 
-        self.assertAllClose(res_pulse.t, res_signal.t, atol=1e-14, rtol=1e-14)
-        self.assertAllClose(res_pulse.y, res_signal.y, atol=1e-14, rtol=1e-14)
+        self.assertAllClose(res_pulse.t, res_signal.t, atol=1e-12, rtol=1e-12)
+        self.assertAllClose(res_pulse.y, res_signal.y, atol=1e-12, rtol=1e-12)
 
     def test_list_simulation_mixing_types(self):
         """Test correct formatting when input states have the same shape.

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -1133,7 +1133,7 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=[np.eye(2, dtype=complex), DensityMatrix([0.0, 1.0])],
             schedules=[sched0, sched1],
             signals=signals,
-            test_tol=1e-9,
+            test_tol=1e-8,
             atol=1e-12,
             rtol=1e-12,
         )

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -418,7 +418,9 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
 
         self.td_lindblad_model.signals = signals
         rwa_td_lindblad_model = rotating_wave_approximation(self.td_lindblad_model, cutoff_freq=5.0)
-        res2 = solve_lmde(generator=rwa_td_lindblad_model, t_span=t_span, y0=y0)
+        res2 = solve_lmde(
+            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
+        )
 
         self.assertAllClose(res1.y, res2.y)
 

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -317,11 +317,11 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.42]
         signals = [Signal(3.0)]
 
-        res1 = lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11)
+        res1 = lindblad_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12)
 
         self.lindblad_model.signals = (signals, None)
         res2 = solve_lmde(
-            generator=self.lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
+            generator=self.lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -342,12 +342,12 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = ([Signal(3.0)], [Signal(2.0)])
 
         res1 = td_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11
+            t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12
         )
 
         self.td_lindblad_model.signals = signals
         res2 = solve_lmde(
-            generator=self.td_lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
+            generator=self.td_lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -367,11 +367,11 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         t_span = [0.0, 1.0]
         signals = [Signal(1.0, carrier_freq=5.0)]
 
-        res1 = rwa_ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11)
+        res1 = rwa_ham_solver.solve(t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12)
 
         self.ham_model.signals = signals
         rwa_ham_model = rotating_wave_approximation(self.ham_model, cutoff_freq=5.0)
-        res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11)
+        res2 = solve_lmde(generator=rwa_ham_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12)
 
         self.assertAllClose(res1.y, res2.y, atol=1e-8, rtol=1e-8)
 
@@ -394,13 +394,13 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = [Signal(1.0, carrier_freq=5.0)]
 
         res1 = rwa_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11
+            t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12
         )
 
         self.lindblad_model.signals = (signals, None)
         rwa_lindblad_model = rotating_wave_approximation(self.lindblad_model, cutoff_freq=5.0)
         res2 = solve_lmde(
-            generator=rwa_lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
+            generator=rwa_lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -425,13 +425,13 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         signals = ([Signal(1.0, carrier_freq=5.0)], [Signal(1.0, carrier_freq=5.0)])
 
         res1 = rwa_td_lindblad_solver.solve(
-            t_span=t_span, y0=y0, signals=signals, atol=1e-11, rtol=1e-11
+            t_span=t_span, y0=y0, signals=signals, atol=1e-12, rtol=1e-12
         )
 
         self.td_lindblad_model.signals = signals
         rwa_td_lindblad_model = rotating_wave_approximation(self.td_lindblad_model, cutoff_freq=5.0)
         res2 = solve_lmde(
-            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-11, rtol=1e-11
+            generator=rwa_td_lindblad_model, t_span=t_span, y0=y0, atol=1e-12, rtol=1e-12
         )
 
         self.assertAllClose(res1.y[-1], res2.y[-1], atol=1e-8, rtol=1e-8)
@@ -580,7 +580,7 @@ class TestSolverSimulation(QiskitDynamicsTestCase):
             rtol=1e-12,
         )
         self.assertTrue(isinstance(results.y[-1], DensityMatrix))
-        self.assertAllClose(results.y[-1].data, results2.y[-1].data, atol=1e-10, rtol=1e-10)
+        self.assertAllClose(results.y[-1].data, results2.y[-1].data, atol=1e-8, rtol=1e-8)
 
     def test_array_vectorized_lindblad(self):
         """Test Lindblad solver is array-vectorized."""
@@ -652,16 +652,16 @@ class TestSolverSimulation(QiskitDynamicsTestCase):
             t_span=[0.0, 0.432],
             y0=SuperOp(np.eye(4)),
             signals=[Signal(1.0, 5.0)],
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-12,
+            rtol=1e-12,
             method=self.method,
         )
         results2 = self.vec_lindblad_solver_no_diss.solve(
             t_span=[0.0, 0.432],
             y0=SuperOp(np.eye(4)),
             signals=[Signal(1.0, 5.0)],
-            atol=1e-10,
-            rtol=1e-10,
+            atol=1e-12,
+            rtol=1e-12,
         )
         self.assertAllClose(results.y[-1].data, results2.y[-1].data, atol=1e-8, rtol=1e-8)
 
@@ -1012,8 +1012,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             schedules=schedule,
             signals=signals,
             test_tol=1e-8,
-            atol=1e-11,
-            rtol=1e-11,
+            atol=1e-12,
+            rtol=1e-12,
         )
 
     def test_rwa_ham_solver(self):
@@ -1047,16 +1047,16 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=Statevector([0.0, 1.0]),
             signals=schedule,
             method=self.method,
-            atol=1e-11,
-            rtol=1e-11,
+            atol=1e-12,
+            rtol=1e-12,
         )
         res_signal = ham_solver.solve(
             t_span=[0, 0.4],
             y0=Statevector([0.0, 1.0]),
             signals=[sig],
             method=self.method,
-            atol=1e-11,
-            rtol=1e-11,
+            atol=1e-12,
+            rtol=1e-12,
         )
 
         self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-8, rtol=1e-8)
@@ -1095,8 +1095,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             signals=schedule,
             method=self.method,
             convert_results=False,
-            atol=1e-11,
-            rtol=1e-11,
+            atol=1e-12,
+            rtol=1e-12,
         )
         res_signal = lindblad_solver.solve(
             t_span=[0, 0.4],
@@ -1104,8 +1104,8 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             signals=[sig],
             method=self.method,
             convert_results=False,
-            atol=1e-11,
-            rtol=1e-11,
+            atol=1e-12,
+            rtol=1e-12,
         )
 
         self.assertAllClose(res_pulse.y[-1], res_signal.y[-1], atol=1e-8, rtol=1e-8)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The macOS tests in CI are currently randomly failing. So far these seem to all be using JAX, though the tests don't have randomness, so it's unclear why these failures are random.

In the past we've had issues with tests reliant on the solutions to ODEs specified with a given numerical tolerance. If the equality tolerance of the test is too close to the tolerance used to solve the ODE, a small change to the solution due to a change in the implementation of some calculation can sometimes push the test over the edge of failure (even though the solution is still fine). I'm going to try to slightly relax the equality tolerances in the offending tests and see if that helps. (This still doesn't explain the randomness, unless there are minor variations in hardware of the testing machines.)

### Details and comments


