### PR TITLE
Move methods into class pages for docs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,6 +1,6 @@
 {#
-   The general principle of this is that we manually document attributes here in
-   the same file, but give all methods their own page.  By default, we document
+   The general principle of this is that we manually document methods and attributes here in
+   the same file.  By default, we document
    all methods, including those defined by parent classes.
 -#}
 
@@ -15,20 +15,17 @@
 #}
    :no-members:
    :show-inheritance:
+   :no-inherited-members:
+   :no-special-members:
 {#
-   Methods all get their own separate page, with their names and the first lines
-   of their docstrings tabulated.  The documentation from `__init__` is
-   automatically included in the standard class documentation, so we don't want
-   to repeat it.
+   The documentation from `__init__` is automatically included in the 
+   standard class documentation, so we don't want to repeat it.
 -#}
 {% block methods_summary %}{% set wanted_methods = (methods | reject('==', '__init__') | list) %}{% if wanted_methods %}
    .. rubric:: Methods
 
-   .. autosummary::
-      :nosignatures:
-      :toctree: ../stubs/
 {% for item in wanted_methods %}
-      ~{{ name }}.{{ item }}
+   .. automethod:: {{ name }}.{{ item }}
 {%- endfor %}
 {% endif %}{% endblock %}
 

--- a/docs/_templates/autosummary/class_no_inherited_members.rst
+++ b/docs/_templates/autosummary/class_no_inherited_members.rst
@@ -14,18 +14,14 @@
 #}
    :no-members:
    :show-inheritance:
-{#
-   Methods all get their own separate page, with their names and the first lines
-   of their docstrings tabulated.
--#}
+   :no-inherited-members:
+   :no-special-members:
+
 {% block methods_summary %}{% set wanted_methods = (methods | reject('in', inherited_members) | reject('==', '__init__') | list) %}{% if wanted_methods %}
    .. rubric:: Methods Defined Here
 
-   .. autosummary::
-      :nosignatures:
-      :toctree: ../stubs/
 {% for item in wanted_methods %}
-      ~{{ name }}.{{ item }}
+   .. automethod:: {{ name }}.{{ item }}
 {%- endfor %}
 {% endif %}{% endblock %}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Moved all the methods into class pages to speed up the building process of the documentation with the new ecosystem sphinx theme. This change helps with this [PR](https://github.com/Qiskit-Extensions/qiskit-dynamics/pull/246).

See https://github.com/Qiskit/qiskit/pull/10455 for more information.