### PR TITLE
Fix ImportError warnings in test_rotating_frame

### DIFF
--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -501,15 +501,6 @@ class TestRotatingFrameTypeHandling(QiskitDynamicsTestCase):
         self.assertAllCloseSparse(out, y)
         self.assertTrue(isinstance(out, csr_matrix))
 
-        t = 100.12498
-        # y = Array(np.eye(2))
-        out = rotating_frame.state_into_frame(t, y)
-        self.assertAllCloseSparse(out, y)
-        self.assertTrue(isinstance(out, csr_matrix))
-        out = rotating_frame.state_out_of_frame(t, y)
-        self.assertAllCloseSparse(out, y)
-        self.assertTrue(isinstance(out, csr_matrix))
-
     def test_state_transformations_no_frame_qobj_type(self):
         """Test frame transformations with no frame."""
 

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -13,6 +13,8 @@
 
 """tests for rotating_frame.py"""
 
+import warnings
+
 import numpy as np
 
 from qiskit import QiskitError
@@ -505,7 +507,9 @@ class TestRotatingFrameTypeHandling(QiskitDynamicsTestCase):
         """Test frame transformations with no frame."""
 
         try:
-            import qutip
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=Warning)
+                import qutip
         except ImportError:
             return
         rotating_frame = RotatingFrame(None)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #278 

Adds warning suppression to the import of `qutip` in `test_rotating_frame`. This PR also deletes a block of test code that was redundant.

### Details and comments


