### PR TITLE
[WIP] Arraylias integration -Model-

### DIFF
--- a/qiskit_dynamics/arraylias/alias.py
+++ b/qiskit_dynamics/arraylias/alias.py
@@ -78,7 +78,7 @@ DYNAMICS_SCIPY = DYNAMICS_SCIPY_ALIAS()
 ArrayLike = Union[Union[DYNAMICS_NUMPY_ALIAS.registered_types()], list]
 
 
-def _preferred_lib(*args, **kwargs):
+def _preferred_lib(*args):
     """Given a list of args and kwargs with potentially mixed array types, determine the appropriate
     library to dispatch to.
 
@@ -93,13 +93,12 @@ def _preferred_lib(*args, **kwargs):
     Raises:
         QiskitError: if none of the rules apply.
     """
-    args = list(args) + list(kwargs.values())
+    args = list(args)
     if len(args) == 1:
         return DYNAMICS_NUMPY_ALIAS.infer_libs(args[0])
 
     lib0 = DYNAMICS_NUMPY_ALIAS.infer_libs(args[0])[0]
-    lib1 = _preferred_lib(args[1:])[0]
-
+    lib1 = _preferred_lib(*args[1:])[0]
     if lib0 == "numpy" and lib1 == "numpy":
         return "numpy"
     elif lib0 == "jax" or lib1 == "jax":
@@ -121,5 +120,5 @@ def _numpy_multi_dispatch(*args, path, **kwargs):
     Returns:
         Result of evaluating the function at path on the arguments using the preferred library.
     """
-    lib = _preferred_lib(*args, **kwargs)
+    lib = _preferred_lib(*args)
     return DYNAMICS_NUMPY_ALIAS(like=lib, path=path)(*args, **kwargs)

--- a/qiskit_dynamics/arraylias/alias.py
+++ b/qiskit_dynamics/arraylias/alias.py
@@ -18,11 +18,24 @@ Global alias instances.
 
 from typing import Union
 
+from scipy.sparse import spmatrix
+
 from arraylias import numpy_alias, scipy_alias
 
 from qiskit import QiskitError
+from qiskit.quantum_info.operators import Operator
 
 from qiskit_dynamics.array import Array
+
+from .register_functions import (
+    register_asarray,
+    register_matmul,
+    register_multiply,
+    register_rmatmul,
+    register_todense,
+    register_to_numeric_matrix_type,
+    register_tosparse,
+)
 
 # global NumPy and SciPy aliases
 DYNAMICS_NUMPY_ALIAS = numpy_alias()
@@ -31,6 +44,32 @@ DYNAMICS_SCIPY_ALIAS = scipy_alias()
 DYNAMICS_NUMPY_ALIAS.register_type(Array, "numpy")
 DYNAMICS_SCIPY_ALIAS.register_type(Array, "numpy")
 
+# register required custom versions of functions for sparse type here
+DYNAMICS_NUMPY_ALIAS.register_type(spmatrix, lib="scipy_sparse")
+
+try:
+    from jax.experimental.sparse import BCOO
+
+    # register required custom versions of functions for BCOO type here
+    DYNAMICS_NUMPY_ALIAS.register_type(BCOO, lib="jax_sparse")
+except ImportError:
+    pass
+
+# register required custom versions of functions for Operator type here
+DYNAMICS_NUMPY_ALIAS.register_type(Operator, lib="operator")
+
+# register required custom versions of functions for List type here
+# need to discuss registering List type because the coverage of List is too broad.
+DYNAMICS_NUMPY_ALIAS.register_type(list, lib="list")
+
+# register custom functions for numpy_alias
+register_asarray(alias=DYNAMICS_NUMPY_ALIAS)
+register_todense(alias=DYNAMICS_NUMPY_ALIAS)
+register_to_numeric_matrix_type(alias=DYNAMICS_NUMPY_ALIAS)
+register_tosparse(alias=DYNAMICS_NUMPY_ALIAS)
+register_matmul(alias=DYNAMICS_NUMPY_ALIAS)
+register_multiply(alias=DYNAMICS_NUMPY_ALIAS)
+register_rmatmul(alias=DYNAMICS_NUMPY_ALIAS)
 
 DYNAMICS_NUMPY = DYNAMICS_NUMPY_ALIAS()
 DYNAMICS_SCIPY = DYNAMICS_SCIPY_ALIAS()

--- a/qiskit_dynamics/arraylias/register_functions/__init__.py
+++ b/qiskit_dynamics/arraylias/register_functions/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from .asarray import register_asarray
+from .to_dense import register_todense
+from .to_numeric_matrix_type import register_to_numeric_matrix_type
+from .to_sparse import register_tosparse
+from .matmul import register_matmul
+from .rmatmul import register_rmatmul
+from .multiply import register_multiply

--- a/qiskit_dynamics/arraylias/register_functions/__init__.py
+++ b/qiskit_dynamics/arraylias/register_functions/__init__.py
@@ -11,6 +11,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+"""
+Register custom functions using alias
+"""
 
 from .asarray import register_asarray
 from .to_dense import register_todense

--- a/qiskit_dynamics/arraylias/register_functions/asarray.py
+++ b/qiskit_dynamics/arraylias/register_functions/asarray.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Registering asarray functions to alias
+"""
+
+import numpy as np
+from scipy.sparse import csr_matrix, issparse
+
+
+def register_asarray(alias):
+    """register asarray functions to each array libraries"""
+
+    @alias.register_default(path="asarray")
+    def _(arr):
+        return arr
+
+    # @alias.register_function(lib="scipy_sparse", path="asarray")
+    # def _(arr):
+    #     return arr
+
+    @alias.register_function(lib="list", path="asarray")
+    def _(arr):
+        if len(arr) == 0 or isinstance(arr[0], (list, tuple)):
+            return np.asarray(arr)
+        return alias(like=arr[0]).asarray([alias().asarray(sub_arr) for sub_arr in arr])
+
+    @alias.register_fallback(path="asarray")
+    def _(arr):
+        return np.asarray(arr)
+
+    # try:
+    #     from jax.experimental.sparse import BCOO
+
+    #     @alias.register_function(lib="jax_sparse", path="asarray")
+    #     def _(arr):
+    #         return arr
+
+    # except ImportError:
+    #     pass

--- a/qiskit_dynamics/arraylias/register_functions/asarray.py
+++ b/qiskit_dynamics/arraylias/register_functions/asarray.py
@@ -27,9 +27,11 @@ def register_asarray(alias):
     def _(arr):
         return arr
 
-    # @alias.register_function(lib="scipy_sparse", path="asarray")
-    # def _(arr):
-    #     return arr
+    @alias.register_function(lib="scipy_sparse", path="asarray")
+    def _(arr):
+        if issparse(arr):
+            return arr
+        return csr_matrix(arr)
 
     @alias.register_function(lib="list", path="asarray")
     def _(arr):
@@ -41,12 +43,14 @@ def register_asarray(alias):
     def _(arr):
         return np.asarray(arr)
 
-    # try:
-    #     from jax.experimental.sparse import BCOO
+    try:
+        from jax.experimental.sparse import BCOO
 
-    #     @alias.register_function(lib="jax_sparse", path="asarray")
-    #     def _(arr):
-    #         return arr
+        @alias.register_function(lib="jax_sparse", path="asarray")
+        def _(arr):
+            if type(arr).__name__ == "BCOO":
+                return arr
+            return BCOO.fromdense(arr)
 
-    # except ImportError:
-    #     pass
+    except ImportError:
+        pass

--- a/qiskit_dynamics/arraylias/register_functions/matmul.py
+++ b/qiskit_dynamics/arraylias/register_functions/matmul.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Registering matmul functions to alias
+"""
+
+
+def register_matmul(alias):
+    """register matmul functions to each array libraries"""
+
+    @alias.register_function(lib="scipy_sparse", path="matmul")
+    def _(x, y):
+        return x * y
+
+    try:
+        from jax.experimental import sparse as jsparse
+        import jax.numpy as jnp
+
+        jsparse_matmul = jsparse.sparsify(jnp.matmul)
+
+        @alias.register_function(lib="jax_sparse", path="matmul")
+        def _(x, y):
+            return jsparse_matmul(x, y)
+
+    except ImportError:
+        pass

--- a/qiskit_dynamics/arraylias/register_functions/multiply.py
+++ b/qiskit_dynamics/arraylias/register_functions/multiply.py
@@ -36,3 +36,7 @@ def register_multiply(alias):
 
     except ImportError:
         pass
+
+    @alias.register_fallback(path="multiply")
+    def _(x, y):
+        return x * y

--- a/qiskit_dynamics/arraylias/register_functions/multiply.py
+++ b/qiskit_dynamics/arraylias/register_functions/multiply.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Registering multiply functions to alias
+"""
+
+
+def register_multiply(alias):
+    """register multiply functions to each array libraries"""
+
+    @alias.register_function(lib="scipy_sparse", path="multiply")
+    def _(x, y):
+        return x.multiply(y)
+
+    try:
+        from jax.experimental import sparse as jsparse
+        import jax.numpy as jnp
+
+        jsparse_multiply = jsparse.sparsify(jnp.multiply)
+
+        @alias.register_function(lib="jax_sparse", path="multiply")
+        def _(x, y):
+            return jsparse_multiply(x, y)
+
+    except ImportError:
+        pass

--- a/qiskit_dynamics/arraylias/register_functions/rmatmul.py
+++ b/qiskit_dynamics/arraylias/register_functions/rmatmul.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""
+Registering rmatmul functions to alias
+"""
+
+import numpy as np
+
+
+def register_rmatmul(alias):
+    """register rmatmul functions to each array libraries"""
+
+    @alias.register_function(lib="numpy", path="rmatmul")
+    def _(x, y):
+        return np.matmul(y, x)
+
+    @alias.register_function(lib="scipy_sparse", path="rmatmul")
+    def _(x, y):
+        return y * x
+
+    try:
+        from jax.experimental import sparse as jsparse
+        import jax.numpy as jnp
+
+        jsparse_matmul = jsparse.sparsify(jnp.matmul)
+
+        @alias.register_function(lib="jax", path="rmatmul")
+        def _(x, y):
+            return jnp.matmul(y, x)
+
+        @alias.register_function(lib="jax_sparse", path="rmatmul")
+        def _(x, y):
+            return jsparse_matmul(y, x)
+
+    except ImportError:
+        pass

--- a/qiskit_dynamics/arraylias/register_functions/to_dense.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_dense.py
@@ -33,6 +33,9 @@ def register_todense(alias):
         return arr
 
     try:
+        # check if jax libraries are registered by import jax
+        # pylint: disable=unused-import
+        import jax
 
         @alias.register_function(lib="jax", path="to_dense")
         def _(arr):

--- a/qiskit_dynamics/arraylias/register_functions/to_dense.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_dense.py
@@ -17,6 +17,7 @@ Registering to_dense functions to alias
 """
 
 import numpy as np
+from arraylias.exceptions import LibraryError
 
 
 def register_todense(alias):
@@ -33,9 +34,6 @@ def register_todense(alias):
         return arr
 
     try:
-        # check if jax libraries are registered by import jax
-        # pylint: disable=unused-import
-        import jax
 
         @alias.register_function(lib="jax", path="to_dense")
         def _(arr):
@@ -45,7 +43,7 @@ def register_todense(alias):
         def _(arr):
             return arr.todense()
 
-    except ImportError:
+    except LibraryError:
         pass
 
     @alias.register_function(lib="scipy_sparse", path="to_dense")

--- a/qiskit_dynamics/arraylias/register_functions/to_dense.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_dense.py
@@ -23,36 +23,36 @@ def register_todense(alias):
     """register to_dense functions to each array libraries"""
 
     @alias.register_default(path="to_dense")
-    def _(op):
-        if op is None:
+    def _(arr):
+        if arr is None:
             return None
-        return op
+        return arr
 
-    # @alias.register_function(lib="numpy", path="to_dense")
-    # def _(op):
-    #     return op
+    @alias.register_function(lib="numpy", path="to_dense")
+    def _(arr):
+        return arr
 
     try:
 
-        # @alias.register_function(lib="jax", path="to_dense")
-        # def _(op):
-        #     return op
+        @alias.register_function(lib="jax", path="to_dense")
+        def _(arr):
+            return arr
 
         @alias.register_function(lib="jax_sparse", path="to_dense")
-        def _(op):
-            return op.todense()
+        def _(arr):
+            return arr.todense()
 
     except ImportError:
         pass
 
     @alias.register_function(lib="scipy_sparse", path="to_dense")
-    def _(op):
-        return op.toarray()
-
-    @alias.register_fallback(path="to_dense")
-    def _(op):
-        return np.asarray(op)
+    def _(arr):
+        return arr.toarray()
 
     @alias.register_function(lib="list", path="to_dense")
-    def _(op):
-        return alias().asarray([alias().to_dense(sub_op) for sub_op in op])
+    def _(arr):
+        return alias().asarray([alias().to_dense(sub_arr) for sub_arr in arr])
+
+    @alias.register_fallback(path="to_dense")
+    def _(arr):
+        return np.asarray(arr)

--- a/qiskit_dynamics/arraylias/register_functions/to_dense.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_dense.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Registering to_dense functions to alias
+"""
+
+import numpy as np
+
+
+def register_todense(alias):
+    """register to_dense functions to each array libraries"""
+
+    @alias.register_default(path="to_dense")
+    def _(op):
+        if op is None:
+            return None
+        return op
+
+    # @alias.register_function(lib="numpy", path="to_dense")
+    # def _(op):
+    #     return op
+
+    try:
+
+        # @alias.register_function(lib="jax", path="to_dense")
+        # def _(op):
+        #     return op
+
+        @alias.register_function(lib="jax_sparse", path="to_dense")
+        def _(op):
+            return op.todense()
+
+    except ImportError:
+        pass
+
+    @alias.register_function(lib="scipy_sparse", path="to_dense")
+    def _(op):
+        return op.toarray()
+
+    @alias.register_fallback(path="to_dense")
+    def _(op):
+        return np.asarray(op)
+
+    @alias.register_function(lib="list", path="to_dense")
+    def _(op):
+        return alias().asarray([alias().to_dense(sub_op) for sub_op in op])

--- a/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
@@ -18,6 +18,7 @@ Registering to_numeric_matrix_type functions to alias
 
 from scipy.sparse import spmatrix
 from qiskit_dynamics.type_utils import isinstance_qutip_qobj
+from arraylias.exceptions import LibraryError
 
 
 def register_to_numeric_matrix_type(alias):
@@ -40,9 +41,6 @@ def register_to_numeric_matrix_type(alias):
         return alias().to_dense(arr)
 
     try:
-        # check if jax libraries are registered by import jax
-        # pylint: disable=unused-import
-        import jax
 
         @alias.register_function(lib="jax", path="to_numeric_matrix_type")
         def _(arr):
@@ -52,7 +50,7 @@ def register_to_numeric_matrix_type(alias):
         def _(arr):
             return arr
 
-    except ImportError:
+    except LibraryError:
         pass
 
     @alias.register_function(lib="scipy_sparse", path="to_numeric_matrix_type")

--- a/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
@@ -17,8 +17,8 @@ Registering to_numeric_matrix_type functions to alias
 """
 
 from scipy.sparse import spmatrix
-from qiskit_dynamics.type_utils import isinstance_qutip_qobj
 from arraylias.exceptions import LibraryError
+from qiskit_dynamics.type_utils import isinstance_qutip_qobj
 
 
 def register_to_numeric_matrix_type(alias):

--- a/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
@@ -40,6 +40,9 @@ def register_to_numeric_matrix_type(alias):
         return alias().to_dense(arr)
 
     try:
+        # check if jax libraries are registered by import jax
+        # pylint: disable=unused-import
+        import jax
 
         @alias.register_function(lib="jax", path="to_numeric_matrix_type")
         def _(arr):

--- a/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Registering to_numeric_matrix_type functions to alias
+"""
+
+from scipy.sparse import spmatrix
+from qiskit_dynamics.type_utils import isinstance_qutip_qobj
+
+
+def register_to_numeric_matrix_type(alias):
+    """register to_numeric_matrix_type functions to each array libraries"""
+
+    @alias.register_default(path="to_numeric_matrix_type")
+    def _(op):
+        if op is None:
+            return None
+        if isinstance_qutip_qobj(op):
+            return alias().to_sparse(op.data)
+        return op
+
+    # @alias.register_function(lib="numpy", path="to_numeric_matrix_type")
+    # def _(op):
+    #     return op
+
+    @alias.register_function(lib="operator", path="to_numeric_matrix_type")
+    def _(op):
+        return alias().to_dense(op)
+
+    # try:
+
+    #     @alias.register_function(lib="jax", path="to_numeric_matrix_type")
+    #     def _(op):
+    #         return op
+
+    #     @alias.register_function(lib="jax_sparse", path="to_numeric_matrix_type")
+    #     def _(op):
+    #         return op
+
+    # except ImportError:
+    #     pass
+
+    # @alias.register_function(lib="scipy_sparse", path="to_numeric_matrix_type")
+    # def _(op):
+    #     return op
+
+    @alias.register_function(lib="list", path="to_numeric_matrix_type")
+    def _(op):
+        if isinstance(op[0], spmatrix) or isinstance_qutip_qobj(op[0]):
+            return [alias().to_sparse(sub_op) for sub_op in op]
+        return alias().asarray([alias().to_dense(sub_op) for sub_op in op])
+
+    @alias.register_fallback(path="to_numeric_matrix_type")
+    def _(op):
+        return op

--- a/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_numeric_matrix_type.py
@@ -24,44 +24,44 @@ def register_to_numeric_matrix_type(alias):
     """register to_numeric_matrix_type functions to each array libraries"""
 
     @alias.register_default(path="to_numeric_matrix_type")
-    def _(op):
-        if op is None:
+    def _(arr):
+        if arr is None:
             return None
-        if isinstance_qutip_qobj(op):
-            return alias().to_sparse(op.data)
-        return op
+        if isinstance_qutip_qobj(arr):
+            return alias().to_sparse(arr.data)
+        return arr
 
-    # @alias.register_function(lib="numpy", path="to_numeric_matrix_type")
-    # def _(op):
-    #     return op
+    @alias.register_function(lib="numpy", path="to_numeric_matrix_type")
+    def _(arr):
+        return arr
 
     @alias.register_function(lib="operator", path="to_numeric_matrix_type")
-    def _(op):
-        return alias().to_dense(op)
+    def _(arr):
+        return alias().to_dense(arr)
 
-    # try:
+    try:
 
-    #     @alias.register_function(lib="jax", path="to_numeric_matrix_type")
-    #     def _(op):
-    #         return op
+        @alias.register_function(lib="jax", path="to_numeric_matrix_type")
+        def _(arr):
+            return arr
 
-    #     @alias.register_function(lib="jax_sparse", path="to_numeric_matrix_type")
-    #     def _(op):
-    #         return op
+        @alias.register_function(lib="jax_sparse", path="to_numeric_matrix_type")
+        def _(arr):
+            return arr
 
-    # except ImportError:
-    #     pass
+    except ImportError:
+        pass
 
-    # @alias.register_function(lib="scipy_sparse", path="to_numeric_matrix_type")
-    # def _(op):
-    #     return op
+    @alias.register_function(lib="scipy_sparse", path="to_numeric_matrix_type")
+    def _(arr):
+        return arr
 
     @alias.register_function(lib="list", path="to_numeric_matrix_type")
-    def _(op):
-        if isinstance(op[0], spmatrix) or isinstance_qutip_qobj(op[0]):
-            return [alias().to_sparse(sub_op) for sub_op in op]
-        return alias().asarray([alias().to_dense(sub_op) for sub_op in op])
+    def _(arr):
+        if isinstance(arr[0], spmatrix) or isinstance_qutip_qobj(arr[0]):
+            return [alias().to_sparse(sub_arr) for sub_arr in arr]
+        return alias().asarray([alias().to_dense(sub_arr) for sub_arr in arr])
 
     @alias.register_fallback(path="to_numeric_matrix_type")
-    def _(op):
-        return op
+    def _(arr):
+        return arr

--- a/qiskit_dynamics/arraylias/register_functions/to_sparse.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_sparse.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Registering asarray functions to alias
+"""
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from qiskit_dynamics.type_utils import isinstance_qutip_qobj
+
+
+def register_tosparse(alias):
+    """register to_sparse functions to each array libraries"""
+
+    @alias.register_default(path="to_sparse")
+    def _(arr):
+        if arr is None:
+            return None
+        if isinstance_qutip_qobj(arr):
+            return arr.data
+        return arr
+
+    @alias.register_function(lib="numpy", path="to_sparse")
+    def _(arr):
+        if arr.ndim < 3:
+            return csr_matrix(arr)
+        return np.array([csr_matrix(sub_arr) for sub_arr in arr])
+
+    try:
+        from jax.experimental.sparse import BCOO
+
+        @alias.register_function(lib="jax", path="to_sparse")
+        def _(arr):
+            return BCOO.fromdense(arr)
+
+        # @alias.register_function(lib="jax_sparse", path="to_sparse")
+        # def _(arr):
+        #     return arr
+
+    except ImportError:
+        pass
+
+    # @alias.register_function(lib="scipy_sparse", path="to_sparse")
+    # def _(arr):
+    #     return arr
+
+    @alias.register_fallback(path="to_sparse")
+    def _(arr):
+        return csr_matrix(arr)
+
+    @alias.register_function(lib="list", path="to_sparse")
+    def _(arr):
+        try:
+            import jax.numpy as jnp
+
+            if isinstance(arr[0], jnp.ndarray):
+                return BCOO.fromdense(arr)
+        except ImportError:
+            pass
+        return np.array([csr_matrix(sub_arr) for sub_arr in arr])

--- a/qiskit_dynamics/arraylias/register_functions/to_sparse.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_sparse.py
@@ -36,7 +36,7 @@ def register_tosparse(alias):
     def _(arr):
         if arr.ndim < 3:
             return csr_matrix(arr)
-        return np.array([csr_matrix(sub_arr) for sub_arr in arr])
+        return [csr_matrix(sub_arr) for sub_arr in arr]
 
     try:
         from jax.experimental.sparse import BCOO

--- a/qiskit_dynamics/arraylias/register_functions/to_sparse.py
+++ b/qiskit_dynamics/arraylias/register_functions/to_sparse.py
@@ -45,20 +45,16 @@ def register_tosparse(alias):
         def _(arr):
             return BCOO.fromdense(arr)
 
-        # @alias.register_function(lib="jax_sparse", path="to_sparse")
-        # def _(arr):
-        #     return arr
+        @alias.register_function(lib="jax_sparse", path="to_sparse")
+        def _(arr):
+            return arr
 
     except ImportError:
         pass
 
-    # @alias.register_function(lib="scipy_sparse", path="to_sparse")
-    # def _(arr):
-    #     return arr
-
-    @alias.register_fallback(path="to_sparse")
+    @alias.register_function(lib="scipy_sparse", path="to_sparse")
     def _(arr):
-        return csr_matrix(arr)
+        return arr
 
     @alias.register_function(lib="list", path="to_sparse")
     def _(arr):
@@ -70,3 +66,7 @@ def register_tosparse(alias):
         except ImportError:
             pass
         return np.array([csr_matrix(sub_arr) for sub_arr in arr])
+
+    @alias.register_fallback(path="to_sparse")
+    def _(arr):
+        return csr_matrix(arr)

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -21,9 +21,10 @@ from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
-from qiskit_dynamics.array import Array
-from qiskit_dynamics.type_utils import to_numeric_matrix_type
 from qiskit_dynamics.signals import Signal, SignalList
+from qiskit_dynamics.arraylias import ArrayLike
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
 from .generator_model import (
     BaseGeneratorModel,
     transfer_static_operator_between_frames,
@@ -105,13 +106,13 @@ class LindbladModel(BaseGeneratorModel):
 
     def __init__(
         self,
-        static_hamiltonian: Optional[Union[Array, csr_matrix]] = None,
-        hamiltonian_operators: Optional[Union[Array, List[csr_matrix]]] = None,
+        static_hamiltonian: Optional[Union[ArrayLike, csr_matrix]] = None,
+        hamiltonian_operators: Optional[Union[ArrayLike, List[csr_matrix]]] = None,
         hamiltonian_signals: Optional[Union[List[Signal], SignalList]] = None,
-        static_dissipators: Optional[Union[Array, csr_matrix]] = None,
-        dissipator_operators: Optional[Union[Array, List[csr_matrix]]] = None,
+        static_dissipators: Optional[Union[ArrayLike, csr_matrix]] = None,
+        dissipator_operators: Optional[Union[ArrayLike, List[csr_matrix]]] = None,
         dissipator_signals: Optional[Union[List[Signal], SignalList]] = None,
-        rotating_frame: Optional[Union[Operator, Array, RotatingFrame]] = None,
+        rotating_frame: Optional[Union[Operator, ArrayLike, RotatingFrame]] = None,
         in_frame_basis: bool = False,
         evaluation_mode: Optional[str] = "dense",
         validate: bool = True,
@@ -151,8 +152,8 @@ class LindbladModel(BaseGeneratorModel):
                 "to be specified at construction."
             )
 
-        static_hamiltonian = to_numeric_matrix_type(static_hamiltonian)
-        hamiltonian_operators = to_numeric_matrix_type(hamiltonian_operators)
+        static_hamiltonian = unp.to_numeric_matrix_type(static_hamiltonian)
+        hamiltonian_operators = unp.to_numeric_matrix_type(hamiltonian_operators)
         if validate:
             if (hamiltonian_operators is not None) and (not is_hermitian(hamiltonian_operators)):
                 raise QiskitError("""LinbladModel hamiltonian_operators must be Hermitian.""")
@@ -180,8 +181,8 @@ class LindbladModel(BaseGeneratorModel):
     def from_hamiltonian(
         cls,
         hamiltonian: HamiltonianModel,
-        static_dissipators: Optional[Union[Array, csr_matrix]] = None,
-        dissipator_operators: Optional[Union[Array, List[csr_matrix]]] = None,
+        static_dissipators: Optional[Union[ArrayLike, csr_matrix]] = None,
+        dissipator_operators: Optional[Union[ArrayLike, List[csr_matrix]]] = None,
         dissipator_signals: Optional[Union[List[Signal], SignalList]] = None,
         evaluation_mode: Optional[str] = None,
     ):
@@ -308,32 +309,32 @@ class LindbladModel(BaseGeneratorModel):
         self._in_frame_basis = in_frame_basis
 
     @property
-    def static_hamiltonian(self) -> Array:
+    def static_hamiltonian(self) -> ArrayLike:
         """The static Hamiltonian term."""
         return self._get_static_hamiltonian(in_frame_basis=self._in_frame_basis)
 
     @static_hamiltonian.setter
-    def static_hamiltonian(self, static_hamiltonian: Array):
+    def static_hamiltonian(self, static_hamiltonian: ArrayLike):
         self._set_static_hamiltonian(
             new_static_hamiltonian=static_hamiltonian, operator_in_frame_basis=self._in_frame_basis
         )
 
     @property
-    def hamiltonian_operators(self) -> Array:
+    def hamiltonian_operators(self) -> ArrayLike:
         """The Hamiltonian operators."""
         return self._get_hamiltonian_operators(in_frame_basis=self._in_frame_basis)
 
     @property
-    def static_dissipators(self) -> Array:
+    def static_dissipators(self) -> ArrayLike:
         """The static dissipator operators."""
         return self._get_static_dissipators(in_frame_basis=self._in_frame_basis)
 
     @property
-    def dissipator_operators(self) -> Array:
+    def dissipator_operators(self) -> ArrayLike:
         """The dissipator operators."""
         return self._get_dissipator_operators(in_frame_basis=self._in_frame_basis)
 
-    def _get_static_hamiltonian(self, in_frame_basis: Optional[bool] = False) -> Array:
+    def _get_static_hamiltonian(self, in_frame_basis: Optional[bool] = False) -> ArrayLike:
         """Get the constant Hamiltonian term.
 
         Args:
@@ -351,7 +352,7 @@ class LindbladModel(BaseGeneratorModel):
 
     def _set_static_hamiltonian(
         self,
-        new_static_hamiltonian: Array,
+        new_static_hamiltonian: ArrayLike,
         operator_in_frame_basis: Optional[bool] = False,
     ):
         """Set the constant Hamiltonian term.
@@ -374,7 +375,9 @@ class LindbladModel(BaseGeneratorModel):
 
             self._operator_collection.static_hamiltonian = new_static_hamiltonian
 
-    def _get_hamiltonian_operators(self, in_frame_basis: Optional[bool] = False) -> Tuple[Array]:
+    def _get_hamiltonian_operators(
+        self, in_frame_basis: Optional[bool] = False
+    ) -> Tuple[ArrayLike]:
         """Get the Hamiltonian operators, either in the frame basis or not.
 
         Args:
@@ -389,7 +392,7 @@ class LindbladModel(BaseGeneratorModel):
 
         return ham_ops
 
-    def _get_static_dissipators(self, in_frame_basis: Optional[bool] = False) -> Tuple[Array]:
+    def _get_static_dissipators(self, in_frame_basis: Optional[bool] = False) -> Tuple[ArrayLike]:
         """Get the static dissipators, either in the frame basis or not.
 
         Args:
@@ -404,7 +407,7 @@ class LindbladModel(BaseGeneratorModel):
 
         return diss_ops
 
-    def _get_dissipator_operators(self, in_frame_basis: Optional[bool] = False) -> Tuple[Array]:
+    def _get_dissipator_operators(self, in_frame_basis: Optional[bool] = False) -> Tuple[ArrayLike]:
         """Get the dissipator operators, either in the frame basis or not.
 
         Args:
@@ -425,7 +428,7 @@ class LindbladModel(BaseGeneratorModel):
 
         Available options:
 
-         * ``'dense'``: Stores Hamiltonian and dissipator terms as dense Array types.
+         * ``'dense'``: Stores Hamiltonian and dissipator terms as dense array types.
          * ``'dense_vectorized'``: Stores the Hamiltonian and dissipator terms as
            :math:`(dim^2,dim^2)` matrices that acts on a vectorized density matrix by
            left-multiplication. Allows for direct evaluate generator.
@@ -469,7 +472,7 @@ class LindbladModel(BaseGeneratorModel):
         return self._rotating_frame
 
     @rotating_frame.setter
-    def rotating_frame(self, rotating_frame: Union[Operator, Array, RotatingFrame]):
+    def rotating_frame(self, rotating_frame: Union[Operator, ArrayLike, RotatingFrame]):
         new_frame = RotatingFrame(rotating_frame)
 
         # convert static hamiltonian to new frame setup
@@ -487,6 +490,7 @@ class LindbladModel(BaseGeneratorModel):
             new_static_hamiltonian = 1j * new_static_hamiltonian
 
         # convert hamiltonian operators and dissipator operators
+
         ham_ops = self._get_hamiltonian_operators(in_frame_basis=True)
         static_diss_ops = self._get_static_dissipators(in_frame_basis=True)
         diss_ops = self._get_dissipator_operators(in_frame_basis=True)
@@ -508,7 +512,6 @@ class LindbladModel(BaseGeneratorModel):
         )
 
         self._rotating_frame = new_frame
-
         self._operator_collection = construct_lindblad_operator_collection(
             evaluation_mode=self.evaluation_mode,
             static_hamiltonian=new_static_hamiltonian,
@@ -517,14 +520,14 @@ class LindbladModel(BaseGeneratorModel):
             dissipator_operators=new_dissipator_operators,
         )
 
-    def evaluate_hamiltonian(self, time: float) -> Array:
+    def evaluate_hamiltonian(self, time: float) -> ArrayLike:
         """Evaluates Hamiltonian matrix at a given time.
 
         Args:
             time: The time at which to evaluate the Hamiltonian.
 
         Returns:
-            Array: Hamiltonian matrix.
+            ArrayLike: Hamiltonian matrix.
         """
 
         hamiltonian_sig_vals = None
@@ -543,14 +546,14 @@ class LindbladModel(BaseGeneratorModel):
 
         return ham
 
-    def evaluate(self, time: float) -> Array:
+    def evaluate(self, time: float) -> ArrayLike:
         """Evaluate the model in array format as a matrix, independent of state.
 
         Args:
             time: The time to evaluate the model at.
 
         Returns:
-            Array: The evaluated model as an anti-Hermitian matrix.
+            ArrayLike: The evaluated model as an anti-Hermitian matrix.
 
         Raises:
             QiskitError: If model cannot be evaluated.
@@ -584,7 +587,7 @@ class LindbladModel(BaseGeneratorModel):
                 "Non-vectorized Lindblad models cannot be represented without a given state."
             )
 
-    def evaluate_rhs(self, time: Union[float, int], y: Array) -> Array:
+    def evaluate_rhs(self, time: Union[float, int], y: ArrayLike) -> ArrayLike:
         """Evaluates the Lindblad model at a given time.
 
         Args:
@@ -593,7 +596,7 @@ class LindbladModel(BaseGeneratorModel):
                (n^2) Array if using vectorized evaluation.
 
         Returns:
-            Array: Either the evaluated generator or the state.
+            ArrayLike: Either the evaluated generator or the state.
 
         Raises:
             QiskitError: If signals not sufficiently specified.
@@ -650,10 +653,10 @@ class LindbladModel(BaseGeneratorModel):
 
 def construct_lindblad_operator_collection(
     evaluation_mode: str,
-    static_hamiltonian: Union[None, Array, csr_matrix],
-    hamiltonian_operators: Union[None, Array, List[csr_matrix]],
-    static_dissipators: Union[None, Array, csr_matrix],
-    dissipator_operators: Union[None, Array, List[csr_matrix]],
+    static_hamiltonian: Union[None, ArrayLike],
+    hamiltonian_operators: Union[None, ArrayLike],
+    static_dissipators: Union[None, ArrayLike],
+    dissipator_operators: Union[None, ArrayLike, List[csr_matrix]],
 ) -> BaseLindbladOperatorCollection:
     """Construct a Lindblad operator collection.
 
@@ -672,13 +675,13 @@ def construct_lindblad_operator_collection(
         NotImplementedError: If ``evaluation_mode`` is not one of the above supported evaluation
             modes.
     """
-
+    is_jax_array = False
+    for op in [static_hamiltonian, hamiltonian_operators, static_dissipators, dissipator_operators]:
+        is_jax_array |= any(
+            lib in ("jax", "jax_sparse") for lib in DYNAMICS_NUMPY_ALIAS.infer_libs(op)
+        )
     # raise warning if sparse mode set with JAX not on cpu
-    if (
-        Array.default_backend() == "jax"
-        and "sparse" in evaluation_mode
-        and jax.default_backend() != "cpu"
-    ):
+    if is_jax_array and "sparse" in evaluation_mode and jax.default_backend() != "cpu":
         warn(
             """Using sparse mode with JAX is primarily recommended for use on CPU.""",
             stacklevel=2,
@@ -687,14 +690,14 @@ def construct_lindblad_operator_collection(
     if evaluation_mode == "dense":
         CollectionClass = DenseLindbladCollection
     elif evaluation_mode == "sparse":
-        if Array.default_backend() == "jax":
+        if is_jax_array:
             CollectionClass = JAXSparseLindbladCollection
         else:
             CollectionClass = SparseLindbladCollection
     elif evaluation_mode == "dense_vectorized":
         CollectionClass = DenseVectorizedLindbladCollection
     elif evaluation_mode == "sparse_vectorized":
-        if Array.default_backend() == "jax":
+        if is_jax_array:
             CollectionClass = JAXSparseVectorizedLindbladCollection
         else:
             CollectionClass = SparseVectorizedLindbladCollection

--- a/qiskit_dynamics/models/rotating_frame.py
+++ b/qiskit_dynamics/models/rotating_frame.py
@@ -17,13 +17,14 @@ Module for rotating frame handling classes.
 
 from typing import Union, List, Optional
 import numpy as np
-from scipy.sparse import issparse, csr_matrix
+from scipy.sparse import issparse
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.operators.predicates import is_hermitian_matrix
-from qiskit_dynamics.array import Array
-from qiskit_dynamics.type_utils import to_array, to_BCOO, to_numeric_matrix_type
+from qiskit_dynamics.arraylias import ArrayLike
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY_ALIAS
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
 
 try:
     import jax.numpy as jnp
@@ -58,7 +59,7 @@ class RotatingFrame:
     """
 
     def __init__(
-        self, frame_operator: Union[Array, Operator], atol: float = 1e-10, rtol: float = 1e-10
+        self, frame_operator: Union[ArrayLike, Operator], atol: float = 1e-10, rtol: float = 1e-10
     ):
         """Initialize with a frame operator.
 
@@ -73,7 +74,7 @@ class RotatingFrame:
             frame_operator = frame_operator.frame_operator
 
         self._frame_operator = frame_operator
-        frame_operator = to_array(frame_operator)
+        frame_operator = unp.to_dense(frame_operator)
 
         if frame_operator is None:
             self._dim = None
@@ -86,7 +87,7 @@ class RotatingFrame:
             # if Hermitian convert to anti-Hermitian
             frame_operator = _enforce_anti_herm(frame_operator, atol=atol, rtol=rtol)
 
-            self._frame_diag = Array(frame_operator)
+            self._frame_diag = unp.asarray(frame_operator)
             self._frame_basis = None
             self._frame_basis_adjoint = None
             self._dim = len(self._frame_diag)
@@ -97,10 +98,10 @@ class RotatingFrame:
             frame_operator = _enforce_anti_herm(frame_operator, atol=atol, rtol=rtol)
 
             # diagonalize with eigh, utilizing assumption of anti-hermiticity
-            frame_diag, frame_basis = np.linalg.eigh(1j * frame_operator)
+            frame_diag, frame_basis = unp.linalg.eigh(1j * frame_operator)
 
-            self._frame_diag = Array(-1j * frame_diag)
-            self._frame_basis = Array(frame_basis)
+            self._frame_diag = -1j * frame_diag
+            self._frame_basis = frame_basis
             self._frame_basis_adjoint = frame_basis.conj().transpose()
             self._dim = len(self._frame_diag)
 
@@ -114,41 +115,41 @@ class RotatingFrame:
         return self._dim
 
     @property
-    def frame_operator(self) -> Array:
+    def frame_operator(self) -> ArrayLike:
         """The original frame operator."""
         return self._frame_operator
 
     @property
-    def frame_diag(self) -> Array:
+    def frame_diag(self) -> ArrayLike:
         """The diagonal of the frame operator."""
         return self._frame_diag
 
     @property
-    def frame_basis(self) -> Array:
+    def frame_basis(self) -> ArrayLike:
         """The array containing diagonalizing unitary."""
         return self._frame_basis
 
     @property
-    def frame_basis_adjoint(self) -> Array:
+    def frame_basis_adjoint(self) -> ArrayLike:
         """The adjoint of the diagonalizing unitary."""
         return self._frame_basis_adjoint
 
-    def state_into_frame_basis(self, y: Array) -> Array:
+    def state_into_frame_basis(self, y: ArrayLike) -> ArrayLike:
         r"""Take a state into the frame basis, i.e. return ``self.frame_basis_adjoint @ y``.
 
         Args:
             y: The state.
 
         Returns:
-            Array: The state in the frame basis.
+            ArrayLike: The state in the frame basis.
         """
-        y = to_numeric_matrix_type(y)
+        y = unp.to_numeric_matrix_type(y)
         if self.frame_basis_adjoint is None:
             return y
 
         return self.frame_basis_adjoint @ y
 
-    def state_out_of_frame_basis(self, y: Array) -> Array:
+    def state_out_of_frame_basis(self, y: ArrayLike) -> ArrayLike:
         r"""Take a state out of the frame basis, i.e. ``return self.frame_basis @ y``.
 
         Args:
@@ -157,7 +158,7 @@ class RotatingFrame:
         Returns:
             Array: The state in the frame basis.
         """
-        y = to_numeric_matrix_type(y)
+        y = unp.to_numeric_matrix_type(y)
         if self.frame_basis is None:
             return y
 
@@ -165,9 +166,9 @@ class RotatingFrame:
 
     def operator_into_frame_basis(
         self,
-        op: Union[Operator, List[Operator], Array, csr_matrix, None],
+        op: Union[Operator, List[Operator], ArrayLike, None],
         convert_type: bool = True,
-    ) -> Array:
+    ) -> ArrayLike:
         r"""Take an operator into the frame basis, i.e. return
         ``self.frame_basis_adjoint @ A @ self.frame_basis``
 
@@ -181,24 +182,21 @@ class RotatingFrame:
             Array: The operator in the frame basis.
         """
         if convert_type:
-            op = to_numeric_matrix_type(op)
+            op = unp.to_numeric_matrix_type(op)
 
         if self.frame_basis is None or op is None:
             return op
 
         if isinstance(op, list):
             return [self.operator_into_frame_basis(x, convert_type=False) for x in op]
-        elif type(op).__name__ == "BCOO":
-            return self.frame_basis_adjoint @ jsparse_matmul(op, self.frame_basis.data)
-        else:
-            # parentheses are necessary for sparse op evaluation
-            return self.frame_basis_adjoint @ (op @ self.frame_basis)
+
+        return unp.rmatmul(unp.matmul(op, self.frame_basis), self.frame_basis_adjoint)
 
     def operator_out_of_frame_basis(
         self,
-        op: Union[Operator, List[Operator], Array, csr_matrix, None],
+        op: Union[Operator, List[Operator], ArrayLike, None],
         convert_type: bool = True,
-    ) -> Array:
+    ) -> ArrayLike:
         r"""Take an operator out of the frame basis, i.e. return
         ``self.frame_basis @ to_array(op) @ self.frame_basis_adjoint``.
 
@@ -209,29 +207,26 @@ class RotatingFrame:
                           that ``op`` is a handled input type.
 
         Returns:
-            Array: The operator in the frame basis.
+            ArrayLike: The operator in the frame basis.
         """
         if convert_type:
-            op = to_numeric_matrix_type(op)
+            op = unp.to_numeric_matrix_type(op)
 
         if self.frame_basis is None or op is None:
             return op
 
         if isinstance(op, list):
             return [self.operator_out_of_frame_basis(x, convert_type=False) for x in op]
-        elif type(op).__name__ == "BCOO":
-            return self.frame_basis @ jsparse_matmul(op, self.frame_basis_adjoint.data)
-        else:
-            # parentheses are necessary for sparse op evaluation
-            return self.frame_basis @ (op @ self.frame_basis_adjoint)
+
+        return unp.rmatmul(unp.matmul(op, self.frame_basis_adjoint), self.frame_basis)
 
     def state_into_frame(
         self,
         t: float,
-        y: Array,
+        y: ArrayLike,
         y_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
-    ):
+    ) -> ArrayLike:
         """Take a state into the rotating frame, i.e. return ``exp(-tF) @ y``.
 
         Args:
@@ -242,9 +237,9 @@ class RotatingFrame:
             return_in_frame_basis: Whether or not to return the result in the frame basis.
 
         Returns:
-            Array: The state in the rotating frame.
+            ArrayLike: The state in the rotating frame.
         """
-        y = to_numeric_matrix_type(y)
+        y = unp.to_numeric_matrix_type(y)
         if self._frame_operator is None:
             return y
 
@@ -255,7 +250,7 @@ class RotatingFrame:
             out = self.state_into_frame_basis(out)
 
         # go into the frame using fast diagonal matrix multiplication
-        out = (np.exp(self.frame_diag * (-t)) * out.transpose()).transpose()  # = e^{tF}out
+        out = (unp.exp(self.frame_diag * (-t)) * out.transpose()).transpose()  # = e^{tF}out
 
         # if output is requested to not be in the frame basis, convert it
         if not return_in_frame_basis:
@@ -266,10 +261,10 @@ class RotatingFrame:
     def state_out_of_frame(
         self,
         t: float,
-        y: Array,
+        y: ArrayLike,
         y_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
-    ) -> Array:
+    ) -> ArrayLike:
         r"""Take a state out of the rotating frame, i.e. return ``exp(tF) @ y``.
 
         Calls ``self.state_into_frame`` with time reversed.
@@ -282,19 +277,19 @@ class RotatingFrame:
             return_in_frame_basis: Whether or not to return the result in the frame basis.
 
         Returns:
-            Array: The state out of the rotating frame.
+            ArrayLike: The state out of the rotating frame.
         """
         return self.state_into_frame(-t, y, y_in_frame_basis, return_in_frame_basis)
 
     def _conjugate_and_add(
         self,
         t: float,
-        operator: Union[Array, csr_matrix],
-        op_to_add_in_fb: Optional[Array] = None,
+        operator: ArrayLike,
+        op_to_add_in_fb: Optional[ArrayLike] = None,
         operator_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
         vectorized_operators: Optional[bool] = False,
-    ) -> Union[Array, csr_matrix]:
+    ) -> ArrayLike:
         r"""General helper function for computing :math:`\exp(-tF)G\exp(tF) + B`.
 
         Note: :math:`B` is added in the frame basis before any potential final change
@@ -314,14 +309,13 @@ class RotatingFrame:
             operator_in_fame_basis: Whether ``operator`` is already in the basis in which the frame
                 operator is diagonal.
             vectorized_operators: Whether ``operator`` is passed as a vectorized, ``(dim**2,)``
-                Array, rather than a ``(dim,dim)`` Array.
+                array, rather than a ``(dim,dim)`` array.
 
         Returns:
             Array of the newly conjugated operator.
         """
-        operator = to_numeric_matrix_type(operator)
-        op_to_add_in_fb = to_numeric_matrix_type(op_to_add_in_fb)
-
+        operator = unp.to_numeric_matrix_type(operator)
+        op_to_add_in_fb = unp.to_numeric_matrix_type(op_to_add_in_fb)
         if vectorized_operators:
             # If passing vectorized operator, undo vectorization temporarily
             if self._frame_operator is None:
@@ -337,11 +331,8 @@ class RotatingFrame:
             if op_to_add_in_fb is None:
                 return operator
             else:
-                if op_to_add_in_fb is not None:
-                    if issparse(operator):
-                        op_to_add_in_fb = csr_matrix(op_to_add_in_fb)
-                    elif type(operator).__name__ == "BCOO":
-                        op_to_add_in_fb = to_BCOO(op_to_add_in_fb)
+                if issparse(operator) or type(operator).__name__ == "BCOO":
+                    op_to_add_in_fb = DYNAMICS_NUMPY_ALIAS(like=operator).asarray(op_to_add_in_fb)
 
                 return operator + op_to_add_in_fb
 
@@ -354,20 +345,14 @@ class RotatingFrame:
         # get frame transformation matrix in diagonal basis
         # assumption that F is anti-Hermitian implies conjugation of
         # diagonal gives inversion
-        exp_freq = np.exp(self.frame_diag * t)
+        exp_freq = unp.exp(self.frame_diag * t)
         frame_mat = exp_freq.conj().reshape(self.dim, 1) * exp_freq
-        if issparse(out):
-            out = out.multiply(frame_mat)
-        elif type(out).__name__ == "BCOO":
-            out = out * frame_mat.data
-        else:
-            out = frame_mat * out
+
+        out = unp.multiply(out, frame_mat)
 
         if op_to_add_in_fb is not None:
-            if issparse(out):
-                op_to_add_in_fb = csr_matrix(op_to_add_in_fb)
-            elif type(out).__name__ == "BCOO":
-                op_to_add_in_fb = to_BCOO(op_to_add_in_fb)
+            if issparse(out) or type(out).__name__ == "BCOO":
+                op_to_add_in_fb = DYNAMICS_NUMPY_ALIAS(like=out).asarray(op_to_add_in_fb)
 
             out = out + op_to_add_in_fb
 
@@ -386,11 +371,11 @@ class RotatingFrame:
     def operator_into_frame(
         self,
         t: float,
-        operator: Union[Operator, Array, csr_matrix],
+        operator: Union[Operator, ArrayLike],
         operator_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
         vectorized_operators: Optional[bool] = False,
-    ) -> Array:
+    ) -> ArrayLike:
         r"""Bring an operator into the frame, i.e. return
         ``exp(-tF) @ operator @ exp(tF)``.
 
@@ -403,10 +388,10 @@ class RotatingFrame:
                 the frame is diagonal.
             return_in_frame_basis: Whether or not to return the result in the frame basis.
             vectorized_operators: Whether ``operator`` is passed as a vectorized,
-                ``(dim**2,)`` Array, rather than a ``(dim,dim)`` Array.
+                ``(dim**2,)`` array, rather than a ``(dim,dim)`` array.
 
         Returns:
-            Array: The operator in the rotating frame.
+            ArrayLike: The operator in the rotating frame.
         """
         return self._conjugate_and_add(
             t,
@@ -419,11 +404,11 @@ class RotatingFrame:
     def operator_out_of_frame(
         self,
         t: float,
-        operator: Union[Operator, Array, csr_matrix],
+        operator: Union[Operator, ArrayLike],
         operator_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
         vectorized_operators: Optional[bool] = False,
-    ):
+    ) -> ArrayLike:
         r"""Bring an operator into the rotating frame, i.e. return
         ``exp(tF) @ operator @ exp(-tF)``.
 
@@ -436,10 +421,10 @@ class RotatingFrame:
                 the frame is diagonal.
             return_in_frame_basis: Whether or not to return the result in the frame basis.
             vectorized_operators: Whether ``operator`` is passed as a vectorized, ``(dim**2,)``
-                Array, rather than a ``(dim,dim)`` Array.
+                array, rather than a ``(dim,dim)`` array.
 
         Returns:
-            Array: The operator out of the rotating frame.
+            ArrayLike: The operator out of the rotating frame.
         """
         return self.operator_into_frame(
             -t,
@@ -452,11 +437,11 @@ class RotatingFrame:
     def generator_into_frame(
         self,
         t: float,
-        operator: Union[Operator, Array, csr_matrix],
+        operator: Union[Operator, ArrayLike],
         operator_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
         vectorized_operators: Optional[bool] = False,
-    ):
+    ) -> ArrayLike:
         r"""Take an generator into the rotating frame, i.e. return
         ``exp(-tF) @ operator @ exp(tF) - F``.
 
@@ -469,19 +454,19 @@ class RotatingFrame:
                 the frame is diagonal.
             return_in_frame_basis: Whether or not to return the result in the frame basis.
             vectorized_operators: Whether ``operator`` is passed as a vectorized, ``(dim**2,)``
-                Array, rather than a ``(dim,dim)`` Array.
+                array, rather than a ``(dim,dim)`` array.
 
         Returns:
-            Array: The generator in the rotating frame.
+            ArrayLike: The generator in the rotating frame.
         """
         if self.frame_operator is None:
-            return to_numeric_matrix_type(operator)
+            return unp.to_numeric_matrix_type(operator)
         else:
             # conjugate and subtract the frame diagonal
             return self._conjugate_and_add(
                 t,
                 operator,
-                op_to_add_in_fb=-np.diag(self.frame_diag),
+                op_to_add_in_fb=-unp.diag(self.frame_diag),
                 operator_in_frame_basis=operator_in_frame_basis,
                 return_in_frame_basis=return_in_frame_basis,
                 vectorized_operators=vectorized_operators,
@@ -490,10 +475,10 @@ class RotatingFrame:
     def generator_out_of_frame(
         self,
         t: float,
-        operator: Union[Operator, Array, csr_matrix],
+        operator: Union[Operator, ArrayLike],
         operator_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
-    ) -> Array:
+    ) -> ArrayLike:
         r"""Take an operator out of the frame using the generator transformaton rule, i.e. return
         ``exp(tF) @ operator @ exp(-tF) + F``.
 
@@ -507,16 +492,16 @@ class RotatingFrame:
             return_in_frame_basis: Whether or not to return the result in the frame basis.
 
         Returns:
-            Array: The generator out of the rotating frame.
+            ArrayLike: The generator out of the rotating frame.
         """
         if self.frame_operator is None:
-            return to_numeric_matrix_type(operator)
+            return unp.to_numeric_matrix_type(operator)
         else:
             # conjugate and add the frame diagonal
             return self._conjugate_and_add(
                 -t,
                 operator,
-                op_to_add_in_fb=Array(np.diag(self.frame_diag)),
+                op_to_add_in_fb=unp.diag(self.frame_diag),
                 operator_in_frame_basis=operator_in_frame_basis,
                 return_in_frame_basis=return_in_frame_basis,
             )
@@ -529,7 +514,7 @@ class RotatingFrame:
             return None
 
         if self._vectorized_frame_basis is None:
-            self._vectorized_frame_basis = np.kron(self.frame_basis.conj(), self.frame_basis)
+            self._vectorized_frame_basis = unp.kron(self.frame_basis.conj(), self.frame_basis)
             self._vectorized_frame_basis_adjoint = self._vectorized_frame_basis.conj().transpose()
 
         return self._vectorized_frame_basis
@@ -551,10 +536,10 @@ class RotatingFrame:
     def vectorized_map_into_frame(
         self,
         time: float,
-        op: Array,
+        op: ArrayLike,
         operator_in_frame_basis: Optional[bool] = False,
         return_in_frame_basis: Optional[bool] = False,
-    ) -> Array:
+    ) -> ArrayLike:
         r"""Given an operator ``op`` of dimension ``dim**2`` assumed to represent vectorized linear
         map in column stacking convention, returns:
 
@@ -567,12 +552,12 @@ class RotatingFrame:
 
         Args:
             time: The time :math:`t`.
-            op: The ``(dim**2,dim**2)`` Array.
+            op: The ``(dim**2,dim**2)`` array.
             operator_in_frame_basis: Whether the operator is in the frame basis.
             return_in_frame_basis: Whether the operator should be returned in the frame basis.
 
         Returns:
-            ``op`` in the frame.
+            ArrayLike: ``op`` in the frame.
         """
         if self.frame_diag is not None:
             # Put the vectorized operator into the frame basis
@@ -596,7 +581,9 @@ class RotatingFrame:
         return op
 
 
-def _enforce_anti_herm(mat: Array, atol: Optional[float] = 1e-10, rtol: Optional[float] = 1e-10):
+def _enforce_anti_herm(
+    mat: ArrayLike, atol: Optional[float] = 1e-10, rtol: Optional[float] = 1e-10
+) -> ArrayLike:
     r"""Given ``mat``, the logic of this function is:
         - if ``mat`` is hermitian, return ``-1j * mat``
         - if ``mat`` is anti-hermitian, return ``mat``
@@ -613,54 +600,57 @@ def _enforce_anti_herm(mat: Array, atol: Optional[float] = 1e-10, rtol: Optional
         rtol: The relative tolerance.
 
     Returns:
-        Array: Anti-hermitian version of ``mat``, if applicable.
+        ArrayLike: Anti-hermitian version of ``mat``, if applicable.
 
     Raises:
         ImportError: If the backend is jax and jax is not installed.
         QiskitError: If ``mat`` is not Hermitian or anti-Hermitian.
     """
-    mat = to_array(mat)
-    mat = Array(mat, dtype=complex)
+    mat = unp.to_dense(mat)
 
-    if mat.backend == "jax":
-        from jax.lax import cond
+    try:
+        from jax.lax import cond, convert_element_type
 
-        mat = mat.data
+        if isinstance(unp.asarray(mat), jnp.ndarray):
+            if mat.ndim == 1:
+                # this function checks if pure imaginary. If yes it returns the
+                # array, otherwise it multiplies it by jnp.nan to raise an error
+                # Note: pathways in conditionals in jax cannot raise Exceptions
+                def anti_herm_conditional(b):
+                    aherm_pred = jnp.allclose(b, -b.conj(), atol=atol, rtol=rtol)
+                    return convert_element_type(
+                        cond(aherm_pred, lambda A: A, lambda A: jnp.nan * A, b), jnp.complex128
+                    )
 
-        if mat.ndim == 1:
-            # this function checks if pure imaginary. If yes it returns the
-            # array, otherwise it multiplies it by jnp.nan to raise an error
-            # Note: pathways in conditionals in jax cannot raise Exceptions
-            def anti_herm_conditional(b):
-                aherm_pred = jnp.allclose(b, -b.conj(), atol=atol, rtol=rtol)
-                return cond(aherm_pred, lambda A: A, lambda A: jnp.nan * A, b)
+                # Check if it is purely real, if not apply anti_herm_conditional
+                herm_pred = jnp.allclose(mat, mat.conj(), atol=atol, rtol=rtol)
+                return unp.asarray(cond(herm_pred, lambda A: -1j * A, anti_herm_conditional, mat))
+            else:
+                # this function checks if anti-hermitian, if yes returns the array,
+                # otherwise it multiplies it by jnp.nan
+                def anti_herm_conditional(b):
+                    aherm_pred = jnp.allclose(b, -b.conj().transpose(), atol=atol, rtol=rtol)
+                    return convert_element_type(
+                        cond(aherm_pred, lambda A: A, lambda A: jnp.nan * A, b), jnp.complex128
+                    )
 
-            # Check if it is purely real, if not apply anti_herm_conditional
-            herm_pred = jnp.allclose(mat, mat.conj(), atol=atol, rtol=rtol)
-            return Array(cond(herm_pred, lambda A: -1j * A, anti_herm_conditional, mat))
-        else:
-            # this function checks if anti-hermitian, if yes returns the array,
-            # otherwise it multiplies it by jnp.nan
-            def anti_herm_conditional(b):
-                aherm_pred = jnp.allclose(b, -b.conj().transpose(), atol=atol, rtol=rtol)
-                return cond(aherm_pred, lambda A: A, lambda A: jnp.nan * A, b)
+                # the following lines check if a is hermitian, otherwise it feeds
+                # it into the anti_herm_conditional
+                herm_pred = jnp.allclose(mat, mat.conj().transpose(), atol=atol, rtol=rtol)
+                return unp.asarray(cond(herm_pred, lambda A: -1j * A, anti_herm_conditional, mat))
+    except (ImportError, NameError):
+        pass
 
-            # the following lines check if a is hermitian, otherwise it feeds
-            # it into the anti_herm_conditional
-            herm_pred = jnp.allclose(mat, mat.conj().transpose(), atol=atol, rtol=rtol)
-            return Array(cond(herm_pred, lambda A: -1j * A, anti_herm_conditional, mat))
-
+    if mat.ndim == 1:
+        if np.allclose(mat, mat.conj(), atol=atol, rtol=rtol):
+            return -1j * mat
+        elif np.allclose(mat, -mat.conj(), atol=atol, rtol=rtol):
+            return mat
     else:
-        if mat.ndim == 1:
-            if np.allclose(mat, mat.conj(), atol=atol, rtol=rtol):
-                return -1j * mat
-            elif np.allclose(mat, -mat.conj(), atol=atol, rtol=rtol):
-                return mat
-        else:
-            if is_hermitian_matrix(mat, rtol=rtol, atol=atol):
-                return -1j * mat
-            elif is_hermitian_matrix(1j * mat, rtol=rtol, atol=atol):
-                return mat
+        if is_hermitian_matrix(mat, rtol=rtol, atol=atol):
+            return -1j * mat
+        elif is_hermitian_matrix(1j * mat, rtol=rtol, atol=atol):
+            return mat
 
-        # raise error if execution has made it this far
-        raise QiskitError("""frame_operator must be either a Hermitian or anti-Hermitian matrix.""")
+    # raise error if execution has made it this far
+    raise QiskitError("""frame_operator must be either a Hermitian or anti-Hermitian matrix.""")

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -89,13 +89,13 @@ class NumpyTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return np.array(a)
 
-    def zeros(self, shape, dtype= None):
+    def zeros(self, shape, dtype=None):
         """Array filled with zeros generation method."""
-        return np.zeros(shape,dtype)
+        return np.zeros(shape, dtype)
 
-    def ones(self, shape, dtype= None):
+    def ones(self, shape, dtype=None):
         """Array filled with ones generation method."""
-        return np.ones(shape,dtype)
+        return np.ones(shape, dtype)
 
     def assertArrayType(self, a):
         """Assert the correct array type."""
@@ -125,13 +125,13 @@ class JAXTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return jnp.array(a)
 
-    def zeros(self, shape, dtype= None):
+    def zeros(self, shape, dtype=None):
         """Array filled with zeros generation method."""
-        return jnp.zeros(shape,dtype)
+        return jnp.zeros(shape, dtype)
 
-    def ones(self, shape, dtype= None):
+    def ones(self, shape, dtype=None):
         """Array filled with ones generation method."""
-        return jnp.ones(shape,dtype)
+        return jnp.ones(shape, dtype)
 
     def assertArrayType(self, a):
         """Assert the correct array type."""
@@ -150,13 +150,13 @@ class ArrayNumpyTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return Array(a)
 
-    def zeros(self, shape, dtype= None):
+    def zeros(self, shape, dtype=None):
         """Array filled with zeros generation method."""
-        return Array(np.zeros(shape,dtype))
+        return Array(np.zeros(shape, dtype))
 
-    def ones(self, shape, dtype= None):
+    def ones(self, shape, dtype=None):
         """Array filled with ones generation method."""
-        return Array(np.ones(shape,dtype))
+        return Array(np.ones(shape, dtype))
 
     def assertArrayType(self, a):
         """Assert the correct array type."""
@@ -193,13 +193,13 @@ class ArrayJaxTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return Array(a)
 
-    def zeros(self, shape, dtype= None):
+    def zeros(self, shape, dtype=None):
         """Array filled with zeros generation method."""
-        return Array(jnp.zeros(shape,dtype))
+        return Array(jnp.zeros(shape, dtype))
 
-    def ones(self, shape, dtype= None):
+    def ones(self, shape, dtype=None):
         """Array filled with ones generation method."""
-        return Array(jnp.ones(shape,dtype))
+        return Array(jnp.ones(shape, dtype))
 
     def assertArrayType(self, a):
         """Assert the correct array type."""

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -89,6 +89,14 @@ class NumpyTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return np.array(a)
 
+    def zeros(self, shape, dtype= None):
+        """Array filled with zeros generation method."""
+        return np.zeros(shape,dtype)
+
+    def ones(self, shape, dtype= None):
+        """Array filled with ones generation method."""
+        return np.ones(shape,dtype)
+
     def assertArrayType(self, a):
         """Assert the correct array type."""
         return isinstance(a, np.ndarray)
@@ -117,6 +125,14 @@ class JAXTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return jnp.array(a)
 
+    def zeros(self, shape, dtype= None):
+        """Array filled with zeros generation method."""
+        return jnp.zeros(shape,dtype)
+
+    def ones(self, shape, dtype= None):
+        """Array filled with ones generation method."""
+        return jnp.ones(shape,dtype)
+
     def assertArrayType(self, a):
         """Assert the correct array type."""
         return isinstance(a, jnp.ndarray)
@@ -133,6 +149,14 @@ class ArrayNumpyTestBase(QiskitDynamicsTestCase):
     def asarray(self, a):
         """Array generation method."""
         return Array(a)
+
+    def zeros(self, shape, dtype= None):
+        """Array filled with zeros generation method."""
+        return Array(np.zeros(shape,dtype))
+
+    def ones(self, shape, dtype= None):
+        """Array filled with ones generation method."""
+        return Array(np.ones(shape,dtype))
 
     def assertArrayType(self, a):
         """Assert the correct array type."""
@@ -168,6 +192,14 @@ class ArrayJaxTestBase(QiskitDynamicsTestCase):
     def asarray(self, a):
         """Array generation method."""
         return Array(a)
+
+    def zeros(self, shape, dtype= None):
+        """Array filled with zeros generation method."""
+        return Array(jnp.zeros(shape,dtype))
+
+    def ones(self, shape, dtype= None):
+        """Array filled with ones generation method."""
+        return Array(jnp.ones(shape,dtype))
 
     def assertArrayType(self, a):
         """Assert the correct array type."""

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -89,14 +89,6 @@ class NumpyTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return np.array(a)
 
-    def zeros(self, shape, dtype=None):
-        """Array filled with zeros generation method."""
-        return np.zeros(shape, dtype)
-
-    def ones(self, shape, dtype=None):
-        """Array filled with ones generation method."""
-        return np.ones(shape, dtype)
-
     def assertArrayType(self, a):
         """Assert the correct array type."""
         return isinstance(a, np.ndarray)
@@ -125,14 +117,6 @@ class JAXTestBase(QiskitDynamicsTestCase):
         """Array generation method."""
         return jnp.array(a)
 
-    def zeros(self, shape, dtype=None):
-        """Array filled with zeros generation method."""
-        return jnp.zeros(shape, dtype)
-
-    def ones(self, shape, dtype=None):
-        """Array filled with ones generation method."""
-        return jnp.ones(shape, dtype)
-
     def assertArrayType(self, a):
         """Assert the correct array type."""
         return isinstance(a, jnp.ndarray)
@@ -149,14 +133,6 @@ class ArrayNumpyTestBase(QiskitDynamicsTestCase):
     def asarray(self, a):
         """Array generation method."""
         return Array(a)
-
-    def zeros(self, shape, dtype=None):
-        """Array filled with zeros generation method."""
-        return Array(np.zeros(shape, dtype))
-
-    def ones(self, shape, dtype=None):
-        """Array filled with ones generation method."""
-        return Array(np.ones(shape, dtype))
 
     def assertArrayType(self, a):
         """Assert the correct array type."""
@@ -192,14 +168,6 @@ class ArrayJaxTestBase(QiskitDynamicsTestCase):
     def asarray(self, a):
         """Array generation method."""
         return Array(a)
-
-    def zeros(self, shape, dtype=None):
-        """Array filled with zeros generation method."""
-        return Array(jnp.zeros(shape, dtype))
-
-    def ones(self, shape, dtype=None):
-        """Array filled with ones generation method."""
-        return Array(jnp.ones(shape, dtype))
 
     def assertArrayType(self, a):
         """Assert the correct array type."""

--- a/test/dynamics/models/test_generator_model.py
+++ b/test/dynamics/models/test_generator_model.py
@@ -807,7 +807,6 @@ class Testtransfer_operator_functionsSparse(QiskitDynamicsTestCase):
 
         out_static = transfer_static_operator_between_frames(static_operator, new_frame=new_frame)
         out_operators = transfer_operators_between_frames(operators, new_frame=new_frame)
-
         self.assertTrue(isinstance(out_static, csr_matrix))
         self.assertTrue(isinstance(out_operators, list) and issparse(out_operators[0]))
 

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -13,36 +13,31 @@
 
 """tests for rotating_frame.py"""
 
+from functools import partial
+import unittest
 import numpy as np
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
 from scipy.sparse import csr_matrix
 from qiskit_dynamics.models.rotating_frame import RotatingFrame
-from qiskit_dynamics.array import Array
-from qiskit_dynamics.type_utils import to_BCOO, to_array
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from qiskit_dynamics.arraylias import ArrayLike
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
+from ..common import JAXTestBase, NumpyTestBase, test_array_backends
+
+# Classes that don't explicitly inherit QiskitDynamicsTestCase get no-member errors
+# pylint: disable=no-member
 
 
-class TestRotatingFrame(QiskitDynamicsTestCase):
+@partial(test_array_backends, array_libraries=["numpy", "jax"])
+class TestRotatingFrame:
     """Tests for RotatingFrame."""
 
     def setUp(self):
-        self.X = Array(Operator.from_label("X").data)
-        self.Y = Array(Operator.from_label("Y").data)
-        self.Z = Array(Operator.from_label("Z").data)
-
-    def test_instantiation_errors(self):
-        """Check different modes of error raising for frame setting."""
-
-        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
-            RotatingFrame(Array([1.0, 1j]))
-
-        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
-            RotatingFrame(Array([[1.0, 0.0], [0.0, 1j]]))
-
-        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
-            RotatingFrame(self.Z + 1j * self.X)
+        """Setup Pauli operators"""
+        self.X = self.asarray(Operator.from_label("X").data)
+        self.Y = self.asarray(Operator.from_label("Y").data)
+        self.Z = self.asarray(Operator.from_label("Z").data)
 
     def test_state_out_of_frame_basis(self):
         """Test state_out_of_frame_basis."""
@@ -52,12 +47,12 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
             low=-10, high=10, size=(6, 6)
         )
 
-        frame_op = Array(rand_op - rand_op.conj().transpose())
+        frame_op = self.asarray(rand_op - rand_op.conj().transpose())
         rotating_frame = RotatingFrame(frame_op)
 
-        _, U = np.linalg.eigh(1j * frame_op)
+        _, U = unp.linalg.eigh(1j * frame_op)
 
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -78,13 +73,13 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
             low=-10, high=10, size=(10, 10)
         )
 
-        frame_op = Array(rand_op - rand_op.conj().transpose())
+        frame_op = self.asarray(rand_op - rand_op.conj().transpose())
         rotating_frame = RotatingFrame(frame_op)
 
         _, U = np.linalg.eigh(1j * frame_op)
         Uadj = U.conj().transpose()
 
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(10, 10))
             + 1j * rng.uniform(low=-10, high=10, size=(10, 10))
         )
@@ -101,7 +96,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         """Test state_into_frame_basis for a list of sparse arrays."""
 
         ops = [csr_matrix([[0.0, 1.0], [1.0, 0.0]]), csr_matrix([[1.0, 0.0], [0.0, -1.0]])]
-        rotating_frame = RotatingFrame(np.array([[0.0, 1.0], [1.0, 0.0]]))
+        rotating_frame = RotatingFrame(self.asarray([[0.0, 1.0], [1.0, 0.0]]))
 
         val = rotating_frame.operator_into_frame_basis(ops)
         U = rotating_frame.frame_basis
@@ -113,7 +108,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         """Test state_out_of_frame_basis for a list of sparse arrays."""
 
         ops = [csr_matrix([[0.0, 1.0], [1.0, 0.0]]), csr_matrix([[1.0, 0.0], [0.0, -1.0]])]
-        rotating_frame = RotatingFrame(np.array([[0.0, 1.0], [1.0, 0.0]]))
+        rotating_frame = RotatingFrame(self.asarray([[0.0, 1.0], [1.0, 0.0]]))
 
         val = rotating_frame.operator_out_of_frame_basis(ops)
         U = rotating_frame.frame_basis
@@ -124,17 +119,17 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def test_state_transformations_no_frame(self):
         """Test frame transformations with no frame."""
 
-        rotating_frame = RotatingFrame(Array(np.zeros(2)))
+        rotating_frame = RotatingFrame(self.asarray(np.zeros(2)))
 
         t = 0.123
-        y = Array([1.0, 1j])
+        y = self.asarray([1.0, 1j])
         out = rotating_frame.state_into_frame(t, y)
         self.assertAllClose(out, y)
         out = rotating_frame.state_out_of_frame(t, y)
         self.assertAllClose(out, y)
 
         t = 100.12498
-        y = Array(np.eye(2))
+        y = self.asarray(np.eye(2))
         out = rotating_frame.state_into_frame(t, y)
         self.assertAllClose(out, y)
         out = rotating_frame.state_out_of_frame(t, y)
@@ -142,9 +137,9 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
 
     def test_state_into_frame_2_level(self):
         """Test state_into_frame with a non-trival frame."""
-        frame_op = -1j * np.pi * (self.X + 0.1 * self.Y + 12.0 * self.Z).data
+        frame_op = -1j * np.pi * (self.X + 0.1 * self.Y + 12.0 * self.Z)
         t = 1312.132
-        y0 = Array([[1.0, 2.0], [3.0, 4.0]])
+        y0 = self.asarray([[1.0, 2.0], [3.0, 4.0]])
 
         self._test_state_into_frame(t, frame_op, y0)
         self._test_state_into_frame(t, frame_op, y0, y_in_frame_basis=True)
@@ -160,10 +155,10 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
             low=-10, high=10, size=(5, 5)
         )
 
-        frame_op = Array(rand_op - rand_op.conj().transpose())
+        frame_op = self.asarray(rand_op - rand_op.conj().transpose())
 
         t = 1312.132
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(5, 5))
             + 1j * rng.uniform(low=-10, high=10, size=(5, 5))
         )
@@ -179,7 +174,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def _test_state_into_frame(
         self, t, frame_op, y, y_in_frame_basis=False, return_in_frame_basis=False
     ):
-        evals, U = np.linalg.eigh(1j * frame_op)
+        evals, U = unp.linalg.eigh(1j * frame_op)
         evals = -1j * evals
 
         rotating_frame = RotatingFrame(frame_op)
@@ -189,7 +184,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         if not y_in_frame_basis:
             expected = U.conj().transpose() @ expected
 
-        expected = np.diag(np.exp(-t * Array(evals))) @ expected
+        expected = unp.diag(unp.exp(-t * self.asarray(evals))) @ expected
 
         if not return_in_frame_basis:
             expected = U @ expected
@@ -198,9 +193,9 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
 
     def test_state_out_of_frame_2_level(self):
         """Test state_out_of_frame with a non-trival frame."""
-        frame_op = -1j * np.pi * (3.1 * self.X + 1.1 * self.Y + 12.0 * self.Z).data
+        frame_op = -1j * np.pi * (3.1 * self.X + 1.1 * self.Y + 12.0 * self.Z)
         t = 122.132
-        y0 = Array([[1.0, 2.0], [3.0, 4.0]])
+        y0 = self.asarray([[1.0, 2.0], [3.0, 4.0]])
         self._test_state_out_of_frame(t, frame_op, y0)
         self._test_state_out_of_frame(t, frame_op, y0, y_in_frame_basis=True)
         self._test_state_out_of_frame(t, frame_op, y0, return_in_frame_basis=True)
@@ -215,10 +210,10 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
             low=-10, high=10, size=(6, 6)
         )
 
-        frame_op = Array(rand_op - rand_op.conj().transpose())
+        frame_op = self.asarray(rand_op - rand_op.conj().transpose())
 
         t = rng.uniform(low=-100, high=100)
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -234,8 +229,8 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def _test_state_out_of_frame(
         self, t, frame_op, y, y_in_frame_basis=False, return_in_frame_basis=False
     ):
-        evals, U = np.linalg.eigh(1j * frame_op)
-        evals = -1j * Array(evals)
+        evals, U = unp.linalg.eigh(1j * frame_op)
+        evals = -1j * self.asarray(evals)
 
         rotating_frame = RotatingFrame(frame_op)
 
@@ -244,7 +239,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         if not y_in_frame_basis:
             expected = U.conj().transpose() @ expected
 
-        expected = np.diag(np.exp(t * evals)) @ expected
+        expected = unp.diag(unp.exp(t * evals)) @ expected
 
         if not return_in_frame_basis:
             expected = U @ expected
@@ -258,10 +253,10 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
             low=-10, high=10, size=(6, 6)
         )
 
-        frame_op = Array(rand_op - rand_op.conj().transpose())
+        frame_op = self.asarray(rand_op - rand_op.conj().transpose())
 
         t = rng.uniform(low=-100, high=100)
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -277,8 +272,8 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def _test_operator_into_frame(
         self, t, frame_op, y, y_in_frame_basis=False, return_in_frame_basis=False
     ):
-        evals, U = np.linalg.eigh(1j * frame_op)
-        evals = -1j * Array(evals)
+        evals, U = unp.linalg.eigh(1j * frame_op)
+        evals = -1j * self.asarray(evals)
         Uadj = U.conj().transpose()
 
         rotating_frame = RotatingFrame(frame_op)
@@ -288,7 +283,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         if not y_in_frame_basis:
             expected = Uadj @ expected @ U
 
-        expected = np.diag(np.exp(-t * evals)) @ expected @ np.diag(np.exp(t * evals))
+        expected = unp.diag(unp.exp(-t * evals)) @ expected @ unp.diag(unp.exp(t * evals))
 
         if not return_in_frame_basis:
             expected = U @ expected @ Uadj
@@ -298,7 +293,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def test_operator_out_of_frame(self):
         """Test operator_out_of_frame."""
         rng = np.random.default_rng(37164093)
-        rand_op = Array(
+        rand_op = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -306,7 +301,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         frame_op = rand_op - rand_op.conj().transpose()
 
         t = rng.uniform(low=-100, high=100)
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -322,8 +317,8 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def _test_operator_out_of_frame(
         self, t, frame_op, y, y_in_frame_basis=False, return_in_frame_basis=False
     ):
-        evals, U = np.linalg.eigh(1j * frame_op)
-        evals = -1j * Array(evals)
+        evals, U = unp.linalg.eigh(1j * frame_op)
+        evals = -1j * self.asarray(evals)
         Uadj = U.conj().transpose()
 
         rotating_frame = RotatingFrame(frame_op)
@@ -333,7 +328,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         if not y_in_frame_basis:
             expected = Uadj @ expected @ U
 
-        expected = np.diag(np.exp(t * evals)) @ expected @ np.diag(np.exp(-t * evals))
+        expected = unp.diag(unp.exp(t * evals)) @ expected @ unp.diag(unp.exp(-t * evals))
 
         if not return_in_frame_basis:
             expected = U @ expected @ Uadj
@@ -343,7 +338,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def test_generator_into_frame(self):
         """Test operator_out_of_frame."""
         rng = np.random.default_rng(111)
-        rand_op = Array(
+        rand_op = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -351,7 +346,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         frame_op = rand_op - rand_op.conj().transpose()
 
         t = rng.uniform(low=-100, high=100)
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -368,8 +363,8 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         self, t, frame_op, y, y_in_frame_basis=False, return_in_frame_basis=False
     ):
         """Helper function for testing generator_into_frame."""
-        evals, U = np.linalg.eigh(1j * frame_op)
-        evals = -1j * Array(evals)
+        evals, U = unp.linalg.eigh(1j * frame_op)
+        evals = -1j * self.asarray(evals)
         Uadj = U.conj().transpose()
 
         rotating_frame = RotatingFrame(frame_op)
@@ -379,7 +374,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         if not y_in_frame_basis:
             expected = Uadj @ expected @ U
 
-        expected = np.diag(np.exp(-t * evals)) @ expected @ np.diag(np.exp(t * evals))
+        expected = unp.diag(unp.exp(-t * evals)) @ expected @ unp.diag(unp.exp(t * evals))
         expected = expected - np.diag(evals)
 
         if not return_in_frame_basis:
@@ -394,10 +389,10 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
             low=-10, high=10, size=(6, 6)
         )
 
-        frame_op = Array(rand_op - rand_op.conj().transpose())
+        frame_op = self.asarray(rand_op - rand_op.conj().transpose())
 
         t = rng.uniform(low=-100, high=100)
-        y0 = Array(
+        y0 = self.asarray(
             rng.uniform(low=-10, high=10, size=(6, 6))
             + 1j * rng.uniform(low=-10, high=10, size=(6, 6))
         )
@@ -414,8 +409,8 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         self, t, frame_op, y, y_in_frame_basis=False, return_in_frame_basis=False
     ):
         """Helper function for testing generator_into_frame."""
-        evals, U = np.linalg.eigh(1j * frame_op)
-        evals = -1j * Array(evals)
+        evals, U = unp.linalg.eigh(1j * frame_op)
+        evals = -1j * self.asarray(evals)
         Uadj = U.conj().transpose()
 
         rotating_frame = RotatingFrame(frame_op)
@@ -425,7 +420,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         if not y_in_frame_basis:
             expected = Uadj @ expected @ U
 
-        expected = np.diag(np.exp(t * evals)) @ expected @ np.diag(np.exp(-t * evals))
+        expected = unp.diag(unp.exp(t * evals)) @ expected @ unp.diag(unp.exp(-t * evals))
         expected = expected + np.diag(evals)
 
         if not return_in_frame_basis:
@@ -437,12 +432,12 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         """Test whether passing a vectorized (dim**2, k) operator to _conjugate_and_add
         with vectorized_operators = True is the same as passing a (k,dim,dim) array of
         operators."""
-        vectorized_rhos = np.array(
+        vectorized_rhos = self.asarray(
             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
         ).transpose()
 
         nonvectord_rhos = vectorized_rhos.reshape((2, 2, 3), order="F").transpose([2, 0, 1])
-        rotating_frame = RotatingFrame(np.array([1j, 2j]))
+        rotating_frame = RotatingFrame(self.asarray([1j, 2j]))
 
         vectorized_result = rotating_frame._conjugate_and_add(
             0.1, vectorized_rhos, vectorized_operators=True
@@ -484,7 +479,8 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         self.assertAllClose(op1, op2.reshape((6, 6), order="F"))
 
 
-class TestRotatingFrameTypeHandling(QiskitDynamicsTestCase):
+@partial(test_array_backends, array_libraries=["numpy", "jax"])
+class TestRotatingFrameTypeHandling:
     """Type handling testing with rotating frame functions"""
 
     def test_state_transformations_no_frame_csr_matrix_type(self):
@@ -502,7 +498,7 @@ class TestRotatingFrameTypeHandling(QiskitDynamicsTestCase):
         self.assertTrue(isinstance(out, csr_matrix))
 
         t = 100.12498
-        # y = Array(np.eye(2))
+        # y = self.asarray(np.eye(2))
         out = rotating_frame.state_into_frame(t, y)
         self.assertAllCloseSparse(out, y)
         self.assertTrue(isinstance(out, csr_matrix))
@@ -562,40 +558,42 @@ class TestRotatingFrameTypeHandling(QiskitDynamicsTestCase):
         rotating_frame = RotatingFrame(None)
 
         t = 0.123
-        y = Array([1.0, 1j])
+        y = self.asarray([1.0, 1j])
         out = rotating_frame.state_into_frame(t, y)
         self.assertAllClose(out, y)
-        self.assertTrue(isinstance(out, Array))
+        self.assertTrue(isinstance(out, ArrayLike))
         out = rotating_frame.state_out_of_frame(t, y)
         self.assertAllClose(out, y)
-        self.assertTrue(isinstance(out, Array))
+        self.assertTrue(isinstance(out, ArrayLike))
 
         t = 100.12498
-        y = Array(np.eye(2))
+        y = self.asarray(np.eye(2))
         out = rotating_frame.state_into_frame(t, y)
         self.assertAllClose(out, y)
-        self.assertTrue(isinstance(out, Array))
+        self.assertTrue(isinstance(out, ArrayLike))
         out = rotating_frame.state_out_of_frame(t, y)
         self.assertAllClose(out, y)
-        self.assertTrue(isinstance(out, Array))
+        self.assertTrue(isinstance(out, ArrayLike))
 
 
-class TestRotatingJAXBCOO(QiskitDynamicsTestCase, TestJaxBase):
+@partial(test_array_backends, array_libraries=["jax"])
+class TestRotatingFrameJAXBCOO:
     """Test correct handling of JAX BCOO arrays in relevant functions."""
 
     def test_conjugate_and_add_BCOO(self):
         """Test _conjugate_and_add with operator being BCOO."""
 
-        rotating_frame = RotatingFrame(np.array([1.0, -1.0]))
+        rotating_frame = RotatingFrame(self.asarray([1.0, -1.0]))
 
         t = 0.123
-        op = to_BCOO(np.array([[1.0, -1j], [0.0, 1.0]]))
-        op_to_add = to_BCOO(np.array([[0.0, -0.11j], [0.0, 1.0]]))
+        op = unp.to_sparse(self.asarray([[1.0, -1j], [0.0, 1.0]]))
+        op_to_add = unp.to_sparse(self.asarray([[0.0, -0.11j], [0.0, 1.0]]))
         out = rotating_frame._conjugate_and_add(t, op, op_to_add)
         self.assertTrue(type(out).__name__ == "BCOO")
 
         self.assertAllClose(
-            to_array(out), rotating_frame._conjugate_and_add(t, to_array(op), to_array(op_to_add))
+            unp.to_dense(out),
+            rotating_frame._conjugate_and_add(t, unp.to_dense(op), unp.to_dense(op_to_add)),
         )
 
     def test_operator_into_frame_basis(self):
@@ -603,11 +601,11 @@ class TestRotatingJAXBCOO(QiskitDynamicsTestCase, TestJaxBase):
         frame specified as full matrix.
         """
 
-        rotating_frame = RotatingFrame(np.array([[1.0, 0.0], [0.0, -1.0]]))
+        rotating_frame = RotatingFrame(self.asarray([[1.0, 0.0], [0.0, -1.0]]))
 
-        op = to_BCOO(np.array([[1.0, -1j], [0.0, 1.0]]))
+        op = unp.to_sparse(self.asarray([[1.0, -1j], [0.0, 1.0]]))
         output = rotating_frame.operator_into_frame_basis(op)
-        expected = rotating_frame.operator_into_frame_basis(to_array(op))
+        expected = rotating_frame.operator_into_frame_basis(unp.to_dense(op))
 
         self.assertAllClose(output, expected)
 
@@ -616,20 +614,57 @@ class TestRotatingJAXBCOO(QiskitDynamicsTestCase, TestJaxBase):
         frame specified as full matrix.
         """
 
-        rotating_frame = RotatingFrame(np.array([[1.0, 0.0], [0.0, -1.0]]))
+        rotating_frame = RotatingFrame(self.asarray([[1.0, 0.0], [0.0, -1.0]]))
 
-        op = to_BCOO(np.array([[1.0, -1j], [0.0, 1.0]]))
+        op = unp.to_sparse(self.asarray([[1.0, -1j], [0.0, 1.0]]))
         output = rotating_frame.operator_out_of_frame_basis(op)
-        expected = rotating_frame.operator_out_of_frame_basis(to_array(op))
+        expected = rotating_frame.operator_out_of_frame_basis(unp.to_dense(op))
 
         self.assertAllClose(output, expected)
 
 
-class TestRotatingFrameJax(TestRotatingFrame, TestJaxBase):
+class TestRotatingFrameNumpy(NumpyTestBase):
+    """Tests for RotatingFrameNumpy."""
+
+    def setUp(self):
+        self.X = self.asarray(Operator.from_label("X").data)
+        self.Y = self.asarray(Operator.from_label("Y").data)
+        self.Z = self.asarray(Operator.from_label("Z").data)
+
+    def test_instantiation_errors(self):
+        """Check different modes of error raising for frame setting."""
+
+        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
+            RotatingFrame(self.asarray([1.0, 1j]))
+
+        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
+            RotatingFrame(self.asarray([[1.0, 0.0], [0.0, 1j]]))
+
+        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
+            RotatingFrame(self.Z + 1j * self.X)
+
+
+class TestRotatingFrameJax(JAXTestBase):
     """Jax version of TestRotatingFrame tests.
 
     Note: This class has more tests due to inheritance.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            # pylint: disable=import-outside-toplevel
+            import jax
+
+            jax.config.update("jax_enable_x64", True)
+            jax.config.update("jax_platform_name", "cpu")
+        except Exception as err:
+            raise unittest.SkipTest("Skipping jax tests.") from err
+
+    def setUp(self):
+        self.X = self.asarray(Operator.from_label("X").data)
+        self.Y = self.asarray(Operator.from_label("Y").data)
+        self.Z = self.asarray(Operator.from_label("Z").data)
 
     def test_instantiation_errors(self):
         """Check different modes of error raising for frame setting.
@@ -639,10 +674,10 @@ class TestRotatingFrameJax(TestRotatingFrame, TestJaxBase):
         # pylint: disable=import-outside-toplevel
         import jax.numpy as jnp
 
-        rotating_frame = RotatingFrame(Array([1.0, 1j]))
+        rotating_frame = RotatingFrame(self.asarray([1.0, 1j]))
         self.assertTrue(jnp.isnan(rotating_frame.frame_diag[0]))
 
-        rotating_frame = RotatingFrame(Array([[1.0, 0.0], [0.0, 1j]]))
+        rotating_frame = RotatingFrame(self.asarray([[1.0, 0.0], [0.0, 1j]]))
         self.assertTrue(jnp.isnan(rotating_frame.frame_diag[0]))
 
         rotating_frame = RotatingFrame(self.Z + 1j * self.X)
@@ -651,19 +686,21 @@ class TestRotatingFrameJax(TestRotatingFrame, TestJaxBase):
     def test_jitting(self):
         """Test jitting of state_into_frame and _conjugate_and_add."""
 
-        rotating_frame = RotatingFrame(Array([1.0, -1.0]))
+        from jax import jit
 
-        self.jit_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0.0, 1.0]))
-        self.jit_wrap(rotating_frame._conjugate_and_add)(
-            t=0.1, operator=np.array([[0.0, 1.0], [1.0, 0.0]])
+        rotating_frame = RotatingFrame(self.asarray([1.0, -1.0]))
+
+        jit(rotating_frame.state_into_frame)(t=0.1, y=self.asarray([0.0, 1.0]))
+        jit(rotating_frame._conjugate_and_add)(
+            t=0.1, operator=self.asarray([[0.0, 1.0], [1.0, 0.0]])
         )
 
     def test_jit_and_grad(self):
         """Test jitting and gradding of state_into_frame and _conjugate_and_add."""
 
-        rotating_frame = RotatingFrame(Array([1.0, -1.0]))
+        from jax import jit, grad
 
-        self.jit_grad_wrap(rotating_frame.state_into_frame)(0.1, np.array([0.0, 1.0]))
-        self.jit_grad_wrap(rotating_frame._conjugate_and_add)(
-            0.1, np.array([[0.0, 1.0], [1.0, 0.0]])
-        )
+        rotating_frame = RotatingFrame(self.asarray([1.0, -1.0]))
+
+        jit(grad(rotating_frame.state_into_frame))(0.1, self.asarray([0.0, 1.0]))
+        jit(grad(rotating_frame._conjugate_and_add))(0.1, self.asarray([[0.0, 1.0], [1.0, 0.0]]))

--- a/test/dynamics/models/test_rotating_wave_approximation.py
+++ b/test/dynamics/models/test_rotating_wave_approximation.py
@@ -136,27 +136,27 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_generator_model_no_rotating_frame(self):
         """Tests whether RWA works in the absence of a rotating frame"""
-        ops = self.ones((4, 2, 2))
+        ops = np.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
-        dft = self.ones((2, 2))
+        dft = np.ones((2, 2))
         GM = GeneratorModel(static_operator=dft, operators=ops, signals=sigs)
         GMP = rotating_wave_approximation(GM, 2)
-        self.assertAllClose(GMP._get_static_operator(True), self.ones((2, 2)))
-        post_rwa_ops = self.asarray([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * self.ones(
+        self.assertAllClose(GMP._get_static_operator(True), np.ones((2, 2)))
+        post_rwa_ops = self.asarray([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * np.ones(
             (8, 2, 2)
         )
         self.assertAllClose(GMP._get_operators(True), post_rwa_ops)
 
     def test_generator_model_no_rotating_frame_no_static_operator(self):
         """Test case of no frame and no static_operator."""
-        ops = self.ones((4, 2, 2))
+        ops = np.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
 
         # test without static_operator
         GM = GeneratorModel(static_operator=None, operators=ops, signals=sigs)
         GMP = rotating_wave_approximation(GM, 2)
         self.assertTrue(GMP.static_operator is None)
-        post_rwa_ops = self.asarray([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * self.ones(
+        post_rwa_ops = self.asarray([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * np.ones(
             (8, 2, 2)
         )
 
@@ -216,7 +216,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
         rwa_ham_model = rotating_wave_approximation(self.classic_hamiltonian, 2 * self.v)
 
-        self.assertAllClose(rwa_ham_model.static_operator, self.zeros((2, 2)))
+        self.assertAllClose(rwa_ham_model.static_operator, np.zeros((2, 2)))
         expected_ops = (
             2
             * np.pi
@@ -258,9 +258,9 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         """Tests signal translation from pre-RWA to post-RWA through
         rotating_wave_approximation.get_rwa_signals when passed a
         GeneratorModel."""
-        ops = self.ones((4, 2, 2))
+        ops = np.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
-        dft = self.ones((2, 2))
+        dft = np.ones((2, 2))
         GM = GeneratorModel(operators=ops, signals=sigs, static_operator=dft, rotating_frame=None)
         f = rotating_wave_approximation(GM, 100, return_signal_map=True)[1]
         vals = f(sigs).complex_value(3)
@@ -276,7 +276,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_signal_translator_lindblad_model(self):
         """Like test_signal_translator_generator_model, but for LindbladModels."""
-        ops = self.ones((4, 2, 2))
+        ops = np.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
         s_prime = [
             Signal(1, 0, -np.pi / 2),
@@ -284,7 +284,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
             Signal(1, 1, -np.pi / 2),
             Signal(1, 3, -np.pi / 2),
         ]
-        dft = self.ones((2, 2))
+        dft = np.ones((2, 2))
         LM = LindbladModel(
             static_hamiltonian=dft,
             hamiltonian_operators=ops,
@@ -341,8 +341,8 @@ class TestRotatingWaveApproximationJax(JAXTestBase):
         """Tests that signal_map from the RWA is jitable and gradable."""
 
         sample_sigs = [Signal(1.0, 0.0), Signal(1.0, -3.0), Signal(1.0, 1.0), Signal(1.0, 3.0)]
-        ops = self.ones((4, 2, 2))
-        static_operator = self.ones((2, 2))
+        ops = np.ones((4, 2, 2))
+        static_operator = np.ones((2, 2))
         model = GeneratorModel(
             operators=ops,
             signals=sample_sigs,
@@ -390,7 +390,7 @@ class TestRotatingWaveApproximationSparse:
 
         rwa_ham_model = rotating_wave_approximation(self.classic_hamiltonian, 2 * self.v)
 
-        self.assertSparseEquality(rwa_ham_model.static_operator, self.zeros((2, 2)))
+        self.assertSparseEquality(rwa_ham_model.static_operator, np.zeros((2, 2)))
         expected_ops = (
             2
             * np.pi

--- a/test/dynamics/models/test_rotating_wave_approximation.py
+++ b/test/dynamics/models/test_rotating_wave_approximation.py
@@ -11,6 +11,9 @@
 # that they have been altered from the originals.
 # pylint: disable=invalid-name
 
+# Classes that don't explicitly inherit QiskitDynamicsTestCase get no-member errors
+# pylint: disable=no-member
+
 """Tests for qiskit_dynamics.models.rotating_wave_approximation"""
 
 from functools import partial
@@ -27,17 +30,18 @@ from qiskit_dynamics.models import (
 )
 from qiskit_dynamics.models.rotating_wave_approximation import get_rwa_operators
 from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
-from ..common import JAXTestBase, QiskitDynamicsTestCase, test_array_backends
+from ..common import JAXTestBase, test_array_backends
 
 # Classes that don't explicitly inherit QiskitDynamicsTestCase get no-member errors
 # pylint: disable=no-member
 
 
 @partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
-class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
+class TestRotatingWaveApproximation:
     """Tests the rotating_wave_approximation function."""
 
     def setUp(self):
+        """Setup Hamiltonian model"""
         self.v = 5.0
         self.r = 0.1
         static_operator = 2 * np.pi * self.v * Operator.from_label("Z") / 2

--- a/test/dynamics/models/test_rotating_wave_approximation.py
+++ b/test/dynamics/models/test_rotating_wave_approximation.py
@@ -13,10 +13,10 @@
 
 """Tests for qiskit_dynamics.models.rotating_wave_approximation"""
 
+from functools import partial
 import numpy as np
 from scipy.sparse import issparse
 from qiskit.quantum_info import Operator
-from qiskit_dynamics.array import Array
 from qiskit_dynamics.signals import Signal, SignalList
 from qiskit_dynamics.models import (
     GeneratorModel,
@@ -26,10 +26,14 @@ from qiskit_dynamics.models import (
     rotating_wave_approximation,
 )
 from qiskit_dynamics.models.rotating_wave_approximation import get_rwa_operators
-from qiskit_dynamics.type_utils import to_array
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
+from ..common import JAXTestBase, QiskitDynamicsTestCase, test_array_backends
+
+# Classes that don't explicitly inherit QiskitDynamicsTestCase get no-member errors
+# pylint: disable=no-member
 
 
+@partial(test_array_backends, array_libraries=["numpy", "jax", "array_numpy", "array_jax"])
 class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
     """Tests the rotating_wave_approximation function."""
 
@@ -49,10 +53,10 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_generator_model_rwa_with_frame(self):
         """Test analytic RWA with a frame operator."""
-        frame_op = np.array([[4j, 1j], [1j, 2j]])
+        frame_op = self.asarray([[4j, 1j], [1j, 2j]])
         sigs = SignalList([Signal(1 + 1j * k, k / 3, np.pi / 2 * k) for k in range(1, 4)])
         self.assertAllClose(sigs(0), np.array([-1, -1, 3]))
-        ops = np.array([[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]])
+        ops = self.asarray([[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]])
 
         GM = GeneratorModel(
             static_operator=None, operators=ops, signals=sigs, rotating_frame=frame_op
@@ -79,10 +83,10 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_generator_model_rwa_with_frame_in_frame_basis(self):
         """Test analytic RWA with a frame operator with model in frame basis."""
-        frame_op = np.array([[4j, 1j], [1j, 2j]])
+        frame_op = self.asarray([[4j, 1j], [1j, 2j]])
         sigs = SignalList([Signal(1 + 1j * k, k / 3, np.pi / 2 * k) for k in range(1, 4)])
         self.assertAllClose(sigs(0), np.array([-1, -1, 3]))
-        ops = np.array([[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]])
+        ops = self.asarray([[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]])
 
         GM = GeneratorModel(
             static_operator=None,
@@ -94,12 +98,14 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         rotating_frame = GM.rotating_frame
         self.assertAllClose(
             GM(0),
-            rotating_frame.operator_into_frame_basis(np.array([[3 - 4j, -1], [-1 - 2j, -3 - 2j]])),
+            rotating_frame.operator_into_frame_basis(
+                self.asarray([[3 - 4j, -1], [-1 - 2j, -3 - 2j]])
+            ),
         )
         self.assertAllClose(
             GM(1),
             rotating_frame.operator_into_frame_basis(
-                np.array(
+                self.asarray(
                     [[-0.552558 - 4j, 3.18653 - 1.43887j], [3.18653 - 0.561126j, 0.552558 - 2j]]
                 )
             ),
@@ -110,14 +116,14 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         self.assertAllClose(
             GM2(0),
             rotating_frame.operator_into_frame_basis(
-                np.array([[0.25 - 4.0j, -0.25 - 0.646447j], [-0.25 - 1.35355j, -0.25 - 2.0j]])
+                self.asarray([[0.25 - 4.0j, -0.25 - 0.646447j], [-0.25 - 1.35355j, -0.25 - 2.0j]])
             ),
             rtol=1e-5,
         )
         self.assertAllClose(
             GM2(1),
             rotating_frame.operator_into_frame_basis(
-                np.array(
+                self.asarray(
                     [
                         [0.0181527 - 4.0j, -0.0181527 - 0.500659j],
                         [-0.0181527 - 1.49934j, -0.0181527 - 2.0j],
@@ -130,37 +136,38 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_generator_model_no_rotating_frame(self):
         """Tests whether RWA works in the absence of a rotating frame"""
-        ops = Array(np.ones((4, 2, 2)))
+        ops = self.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
-        dft = Array(np.ones((2, 2)))
+        dft = self.ones((2, 2))
         GM = GeneratorModel(static_operator=dft, operators=ops, signals=sigs)
         GMP = rotating_wave_approximation(GM, 2)
-        self.assertAllClose(GMP._get_static_operator(True), Array(np.ones((2, 2))))
-        post_rwa_ops = Array(np.array([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1))) * Array(
-            np.ones((8, 2, 2))
+        self.assertAllClose(GMP._get_static_operator(True), self.ones((2, 2)))
+        post_rwa_ops = self.asarray([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * self.ones(
+            (8, 2, 2)
         )
         self.assertAllClose(GMP._get_operators(True), post_rwa_ops)
 
     def test_generator_model_no_rotating_frame_no_static_operator(self):
         """Test case of no frame and no static_operator."""
-        ops = Array(np.ones((4, 2, 2)))
+        ops = self.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
 
         # test without static_operator
         GM = GeneratorModel(static_operator=None, operators=ops, signals=sigs)
         GMP = rotating_wave_approximation(GM, 2)
         self.assertTrue(GMP.static_operator is None)
-        post_rwa_ops = Array(np.array([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1))) * Array(
-            np.ones((8, 2, 2))
+        post_rwa_ops = self.asarray([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * self.ones(
+            (8, 2, 2)
         )
+
         self.assertAllClose(GMP._get_operators(True), post_rwa_ops)
 
     def test_generator_model_rotating_frame_no_operators(self):
         """Test case for GeneratorModel with rotating frame and no operators."""
-        frame_op = 2 * np.pi * np.array([1, -1]) / 2
+        frame_op = 2 * np.pi * self.asarray([1, -1]) / 2
 
         GM = GeneratorModel(
-            static_operator=np.array([[3.0, 1], [1, 2.0]]) - 1j * np.diag(frame_op),
+            static_operator=self.asarray([[3.0, 1], [1, 2.0]]) - 1j * unp.diag(frame_op),
             operators=None,
             signals=None,
             rotating_frame=frame_op,
@@ -170,15 +177,15 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_lindblad_model_rotating_frame_only_static_hamiltonian(self):
         """Test case for LindbladModel with just a static hamiltonian."""
-        frame_op = 2 * np.pi * np.array([1, -1]) / 2
+        frame_op = 2 * np.pi * self.asarray([1, -1]) / 2
 
         model = LindbladModel(
-            static_hamiltonian=np.array([[3.0, 1], [1, 2.0]]) + np.diag(frame_op),
+            static_hamiltonian=self.asarray([[3.0, 1], [1, 2.0]]) + unp.diag(frame_op),
             rotating_frame=frame_op,
         )
         rwa_model = rotating_wave_approximation(model, 1.0)
-        ham = np.array([[3.0, 0], [0, 2.0]])
-        rho = np.array([[1.0, 2.0], [3.0, 4.0]])
+        ham = self.asarray([[3.0, 0], [0, 2.0]])
+        rho = self.asarray([[1.0, 2.0], [3.0, 4.0]])
         expected = -1j * (ham @ rho - rho @ ham)
         self.assertAllClose(rwa_model(0, rho), expected)
 
@@ -187,19 +194,19 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         in frame basis.
         """
 
-        U = np.array([[1.0, 1.0], [1.0, -1.0]]) / np.sqrt(2)
+        U = self.asarray([[1.0, 1.0], [1.0, -1.0]]) / np.sqrt(2)
         Uadj = U.conj().transpose()
         frame_op = 2 * np.pi * U @ np.diag([1, -1]) @ Uadj / 2
 
         model = LindbladModel(
-            static_hamiltonian=U @ np.array([[3.0, 1], [1, 2.0]]) @ Uadj + frame_op,
+            static_hamiltonian=U @ self.asarray([[3.0, 1], [1, 2.0]]) @ Uadj + frame_op,
             rotating_frame=frame_op,
             in_frame_basis=True,
         )
         rwa_model = rotating_wave_approximation(model, 0.99)
         # flipped due to eigenvalue ordering
-        ham = np.array([[2.0, 0], [0, 3.0]])
-        rho = np.array([[1.0, 2.0], [3.0, 4.0]])
+        ham = self.asarray([[2.0, 0], [0, 3.0]])
+        rho = self.asarray([[1.0, 2.0], [3.0, 4.0]])
         expected = -1j * (ham @ rho - rho @ ham)
         self.assertTrue(rwa_model.in_frame_basis)
         self.assertAllClose(rwa_model(0, rho), expected)
@@ -209,9 +216,13 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
         rwa_ham_model = rotating_wave_approximation(self.classic_hamiltonian, 2 * self.v)
 
-        self.assertAllClose(rwa_ham_model.static_operator, np.zeros((2, 2)))
+        self.assertAllClose(rwa_ham_model.static_operator, self.zeros((2, 2)))
         expected_ops = (
-            2 * np.pi * self.r * np.array([[[0.0, 1.0], [1.0, 0.0]], [[0.0, -1j], [1j, 0.0]]]) / 4
+            2
+            * np.pi
+            * self.r
+            * self.asarray([[[0.0, 1.0], [1.0, 0.0]], [[0.0, -1j], [1j, 0.0]]])
+            / 4
         )
         self.assertAllClose(rwa_ham_model.operators, expected_ops)
 
@@ -219,7 +230,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         """Compare evaluation of static dissipators with non-static."""
 
         np.random.seed(2314)
-        random_mats = lambda *args: Array(np.random.uniform(-1, 1, args))
+        random_mats = lambda *args: self.asarray(np.random.uniform(-1, 1, args))
         random_complex_mats = lambda *args: random_mats(*args) + 1j * random_mats(*args)
 
         random_diss = random_complex_mats(3, 2, 2)
@@ -247,9 +258,9 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         """Tests signal translation from pre-RWA to post-RWA through
         rotating_wave_approximation.get_rwa_signals when passed a
         GeneratorModel."""
-        ops = Array(np.ones((4, 2, 2)))
+        ops = self.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
-        dft = Array(np.ones((2, 2)))
+        dft = self.ones((2, 2))
         GM = GeneratorModel(operators=ops, signals=sigs, static_operator=dft, rotating_frame=None)
         f = rotating_wave_approximation(GM, 100, return_signal_map=True)[1]
         vals = f(sigs).complex_value(3)
@@ -265,7 +276,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
     def test_signal_translator_lindblad_model(self):
         """Like test_signal_translator_generator_model, but for LindbladModels."""
-        ops = Array(np.ones((4, 2, 2)))
+        ops = self.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
         s_prime = [
             Signal(1, 0, -np.pi / 2),
@@ -273,7 +284,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
             Signal(1, 1, -np.pi / 2),
             Signal(1, 3, -np.pi / 2),
         ]
-        dft = Array(np.ones((2, 2)))
+        dft = self.ones((2, 2))
         LM = LindbladModel(
             static_hamiltonian=dft,
             hamiltonian_operators=ops,
@@ -293,7 +304,7 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
     def test_rwa_operators(self):
         """Tests get_rwa_operators using pseudorandom numbers."""
         np.random.seed(123098123)
-        r = lambda *args: Array(np.random.uniform(-1, 1, args))
+        r = lambda *args: self.asarray(np.random.uniform(-1, 1, args))
         rj = lambda *args: r(*args) + 1j * r(*args)
         ops = rj(4, 3, 3)
         carrier_freqs = r(4)
@@ -306,15 +317,15 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
 
         ops_in_fb = rotating_frame.operator_into_frame_basis(ops)
         diag = rotating_frame.frame_diag
-        diff_matrix = np.broadcast_to(diag, (3, 3)) - np.broadcast_to(diag, (3, 3)).T
+        diff_matrix = unp.broadcast_to(diag, (3, 3)) - unp.broadcast_to(diag, (3, 3)).T
         frame_freqs = diff_matrix.imag / (2 * np.pi)
 
         rwa_ops = get_rwa_operators(ops_in_fb, sigs, rotating_frame, frame_freqs, cutoff_freq)
 
         carrier_freqs = carrier_freqs.reshape(4, 1, 1)
         frame_freqs = frame_freqs.reshape(1, 3, 3)
-        G_p = ops_in_fb * (np.abs(carrier_freqs + frame_freqs) < cutoff_freq).astype(int)
-        G_m = ops_in_fb * (np.abs(-carrier_freqs + frame_freqs) < cutoff_freq).astype(int)
+        G_p = ops_in_fb * (unp.abs(carrier_freqs + frame_freqs) < cutoff_freq).astype(int)
+        G_m = ops_in_fb * (unp.abs(-carrier_freqs + frame_freqs) < cutoff_freq).astype(int)
         self.assertAllClose(
             rwa_ops[:4], rotating_frame.operator_out_of_frame_basis((G_p + G_m) / 2)
         )
@@ -323,15 +334,15 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
         )
 
 
-class TestRotatingWaveApproximationJax(TestRotatingWaveApproximation, TestJaxBase):
+class TestRotatingWaveApproximationJax(JAXTestBase):
     """Jax version of TestRotatingWaveApproximation tests."""
 
     def test_jitable_gradable_signal_map(self):
         """Tests that signal_map from the RWA is jitable and gradable."""
 
         sample_sigs = [Signal(1.0, 0.0), Signal(1.0, -3.0), Signal(1.0, 1.0), Signal(1.0, 3.0)]
-        ops = Array(np.ones((4, 2, 2)))
-        static_operator = Array(np.ones((2, 2)))
+        ops = self.ones((4, 2, 2))
+        static_operator = self.ones((2, 2))
         model = GeneratorModel(
             operators=ops,
             signals=sample_sigs,
@@ -349,14 +360,17 @@ class TestRotatingWaveApproximationJax(TestRotatingWaveApproximation, TestJaxBas
             rwa_model_copy.signals = signal_map(sigs)
             return rwa_model(t)
 
-        self.jit_wrap(_simple_function_using_rwa)(1.0, 1.0)
+        from jax import jit
+
+        jit(_simple_function_using_rwa)(1.0, 1.0)
         self.jit_grad_wrap(_simple_function_using_rwa)(1.0, 1.0)
 
 
-class TestRotatingWaveApproximationSparse(QiskitDynamicsTestCase):
+class TestRotatingWaveApproximationSparse:
     """Tests the rotating_wave_approximation function for sparse models."""
 
     def setUp(self):
+        """Setup Hamiltonian model"""
         self.v = 5.0
         self.r = 0.1
         static_operator = 2 * np.pi * self.v * Operator.from_label("Z") / 2
@@ -376,9 +390,13 @@ class TestRotatingWaveApproximationSparse(QiskitDynamicsTestCase):
 
         rwa_ham_model = rotating_wave_approximation(self.classic_hamiltonian, 2 * self.v)
 
-        self.assertSparseEquality(rwa_ham_model.static_operator, np.zeros((2, 2)))
+        self.assertSparseEquality(rwa_ham_model.static_operator, self.zeros((2, 2)))
         expected_ops = (
-            2 * np.pi * self.r * np.array([[[0.0, 1.0], [1.0, 0.0]], [[0.0, -1j], [1j, 0.0]]]) / 4
+            2
+            * np.pi
+            * self.r
+            * self.asarray([[[0.0, 1.0], [1.0, 0.0]], [[0.0, -1j], [1j, 0.0]]])
+            / 4
         )
         self.assertSparseEquality(rwa_ham_model.operators, expected_ops)
 
@@ -390,13 +408,17 @@ class TestRotatingWaveApproximationSparse(QiskitDynamicsTestCase):
         else:
             self.assertTrue(issparse(op))
 
-        self.assertAllClose(to_array(op), to_array(expected))
+        self.assertAllClose(unp.to_dense(op), unp.to_dense(expected))
 
 
-class TestRotatingWaveApproximationSparseJax(TestRotatingWaveApproximationSparse, TestJaxBase):
+class TestRotatingWaveApproximationSparseJax(TestRotatingWaveApproximationSparse):
     """JAX version of TestRotatingWaveApproximationSparse."""
 
     def assertSparseEquality(self, op, expected):
         """Validate that op is sparse and is equal to expected."""
         self.assertTrue(type(op).__name__ == "BCOO")
-        self.assertAllClose(to_array(op), to_array(expected))
+        self.assertAllClose(unp.to_dense(op), unp.to_dense(expected))
+
+
+test_array_backends(TestRotatingWaveApproximationSparse, array_libraries=["numpy", "array_numpy"])
+test_array_backends(TestRotatingWaveApproximationSparseJax, array_libraries=["jax", "array_jax"])

--- a/test/dynamics/test_type_utils.py
+++ b/test/dynamics/test_type_utils.py
@@ -276,7 +276,7 @@ class Testvec_commutator_dissipator(QiskitDynamicsTestCase):
         )
 
 
-class Test_to_dense(NumpyTestBase):
+class Test_to_dense(QiskitDynamicsTestCase):
     """Tests for to_dense."""
 
     def test_None_to_None(self):
@@ -339,12 +339,10 @@ class Test_to_dense(NumpyTestBase):
         """Type conversion tests for to_dense"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         numpy_ops = np.array(list_of_ops)
-        normal_array = unp.asarray(np.array(list_of_ops))
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         single_op = op_arr[0]
         list_of_arrays = [Array(op) for op in list_of_ops]
         assert isinstance(unp.to_dense(numpy_ops), np.ndarray)
-        assert isinstance(unp.to_dense(normal_array), np.ndarray)
         assert isinstance(unp.to_dense(op_arr), np.ndarray)
         assert isinstance(unp.to_dense(single_op), np.ndarray)
         assert isinstance(unp.to_dense(list_of_arrays), np.ndarray)
@@ -357,12 +355,10 @@ class Test_to_dense_Jax(Test_to_dense, TestJaxBase):
         """Type conversion tests for to_dense with jax backend"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         numpy_ops = np.array(list_of_ops)
-        normal_array = unp.asarray(np.array(list_of_ops))
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         single_op = op_arr[0]
         list_of_arrays = [unp.asarray(op) for op in list_of_ops]
         assert isinstance(unp.to_dense(numpy_ops), np.ndarray)
-        assert isinstance(unp.to_dense(normal_array), np.ndarray)
         assert isinstance(unp.to_dense(op_arr), np.ndarray)
         assert isinstance(unp.to_dense(single_op), np.ndarray)
         assert isinstance(unp.to_dense(list_of_arrays), np.ndarray)

--- a/test/dynamics/test_type_utils.py
+++ b/test/dynamics/test_type_utils.py
@@ -26,15 +26,17 @@ from qiskit_dynamics.type_utils import (
     vec_dissipator,
     vec_commutator,
     to_array,
-    to_csr,
     to_BCOO,
     to_numeric_matrix_type,
 )
 
-from .common import QiskitDynamicsTestCase, TestJaxBase, QutipTestBase
+from qiskit_dynamics.arraylias import DYNAMICS_NUMPY as unp
+
+from .common import JAXTestBase, NumpyTestBase, QiskitDynamicsTestCase, TestJaxBase, QutipTestBase
 
 try:
     from jax.experimental import sparse as jsparse
+    import jax.numpy as jnp
 except ImportError:
     pass
 
@@ -274,177 +276,175 @@ class Testvec_commutator_dissipator(QiskitDynamicsTestCase):
         )
 
 
-class Test_to_array(QiskitDynamicsTestCase):
-    """Tests for to_array."""
+class Test_to_dense(NumpyTestBase):
+    """Tests for to_dense."""
 
     def test_None_to_None(self):
         """Test that None input returns None."""
-        self.assertTrue(to_array(None) is None)
+        self.assertTrue(unp.to_dense(None) is None)
 
-    def test_to_array_Operator(self):
-        """Tests for to_array with a single operator"""
+    def test_to_dense_Operator(self):
+        """Tests for to_dense with a single operator"""
         op = Operator.from_label("X")
-        self.assertAllClose(to_array(op), Array([[0, 1], [1, 0]]))
+        self.assertAllClose(unp.to_dense(op), np.array([[0, 1], [1, 0]]))
 
-    def test_to_array_nparray(self):
-        """Tests for to_array with a single numpy array"""
+    def test_to_dense_nparray(self):
+        """Tests for to_dense with a single numpy array"""
         ndarray = np.array([[0, 1], [1, 0]])
-        self.assertAllClose(to_array(ndarray), ndarray)
+        self.assertAllClose(unp.to_dense(ndarray), ndarray)
 
-    def test_to_array_Array(self):
-        """Tests for to_array from a qiskit Array"""
+    def test_to_dense_Array(self):
+        """Tests for to_dense from a qiskit Array"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
-        arr_in = Array(list_of_ops)
-        self.assertAllClose(to_array(arr_in), arr_in)
+        arr_in = unp.asarray(list_of_ops)
+        self.assertAllClose(unp.to_dense(arr_in), arr_in)
 
-    def test_to_array_sparse_matrix(self):
-        """Tests for to_array with a single sparse matrix"""
+    def test_to_dense_sparse_matrix(self):
+        """Tests for to_dense with a single sparse matrix"""
         op = Operator.from_label("X")
         spm = csr_matrix(op)
-        ar = Array(op)
-        self.assertAllClose(to_array(spm), ar)
+        ar = unp.asarray(op)
+        self.assertAllClose(unp.to_dense(spm), ar)
 
-    def test_to_array_Operator_list(self):
-        """Tests for to_array with a list of operators"""
+    def test_to_dense_Operator_list(self):
+        """Tests for to_dense with a list of operators"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         op_arr = [Operator.from_label(s) for s in "XYZ"]
-        normal_array = Array(np.array(list_of_ops))
-        self.assertAllClose(to_array(op_arr), normal_array)
+        normal_array = unp.asarray(np.array(list_of_ops))
+        self.assertAllClose(unp.to_dense(op_arr), normal_array)
 
-    def test_to_array_nparray_list(self):
-        """Tests for to_array with a list of numpy arrays"""
+    def test_to_dense_nparray_list(self):
+        """Tests for to_dense with a list of numpy arrays"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         ndarray_list = [np.array(op) for op in list_of_ops]
-        list_of_arrays = [Array(op) for op in list_of_ops]
-        self.assertAllClose(to_array(ndarray_list), list_of_arrays)
+        list_of_arrays = [unp.asarray(op) for op in list_of_ops]
+        self.assertAllClose(unp.to_dense(ndarray_list), list_of_arrays)
 
-    def test_to_array_list_of_arrays(self):
-        """Tests for to_array with a list of numpy arrays"""
+    def test_to_dense_list_of_arrays(self):
+        """Tests for to_dense with a list of numpy arrays"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         ndarray_list = [np.array(op) for op in list_of_ops]
-        list_of_arrays = [Array(op) for op in list_of_ops]
-        big_array = Array(list_of_arrays)
-        self.assertAllClose(to_array(ndarray_list), big_array)
+        list_of_arrays = [unp.asarray(op) for op in list_of_ops]
+        big_array = unp.asarray(list_of_arrays)
+        self.assertAllClose(unp.to_dense(ndarray_list), big_array)
 
-    def test_to_array_sparse_matrix_list(self):
-        """Tests for to_array with a list of sparse matrices"""
+    def test_to_dense_sparse_matrix_list(self):
+        """Tests for to_dense with a list of sparse matrices"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
-        list_of_arrays = [Array(op) for op in list_of_ops]
+        list_of_arrays = [unp.asarray(op) for op in list_of_ops]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
-        self.assertAllClose(to_array(sparse_matrices), list_of_arrays)
+        self.assertAllClose(unp.to_dense(sparse_matrices), list_of_arrays)
 
-    def test_to_array_types(self):
-        """Type conversion tests for to_array"""
+    def test_to_dense_types(self):
+        """Type conversion tests for to_dense"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         numpy_ops = np.array(list_of_ops)
-        normal_array = Array(np.array(list_of_ops))
+        normal_array = unp.asarray(np.array(list_of_ops))
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         single_op = op_arr[0]
         list_of_arrays = [Array(op) for op in list_of_ops]
-        assert isinstance(to_array(numpy_ops), np.ndarray)
-        assert isinstance(to_array(normal_array), Array)
-        assert isinstance(to_array(op_arr), np.ndarray)
-        assert isinstance(to_array(single_op), np.ndarray)
-        assert isinstance(to_array(list_of_arrays), np.ndarray)
+        assert isinstance(unp.to_dense(numpy_ops), np.ndarray)
+        assert isinstance(unp.to_dense(normal_array), np.ndarray)
+        assert isinstance(unp.to_dense(op_arr), np.ndarray)
+        assert isinstance(unp.to_dense(single_op), np.ndarray)
+        assert isinstance(unp.to_dense(list_of_arrays), np.ndarray)
 
 
-class Test_to_array_Jax(Test_to_array, TestJaxBase):
-    """Jax version of Test_to_array tests."""
+class Test_to_dense_Jax(Test_to_dense, TestJaxBase):
+    """Jax version of Test_to_dense tests."""
 
-    def test_to_array_types(self):
-        """Type conversion tests for to_array with jax backend"""
+    def test_to_dense_types(self):
+        """Type conversion tests for to_dense with jax backend"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         numpy_ops = np.array(list_of_ops)
-        normal_array = Array(np.array(list_of_ops))
+        normal_array = unp.asarray(np.array(list_of_ops))
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         single_op = op_arr[0]
-        list_of_arrays = [Array(op) for op in list_of_ops]
-        assert isinstance(to_array(numpy_ops), Array)
-        assert isinstance(to_array(normal_array), Array)
-        assert isinstance(to_array(op_arr), Array)
-        assert isinstance(to_array(single_op), Array)
-        assert isinstance(to_array(list_of_arrays), Array)
+        list_of_arrays = [unp.asarray(op) for op in list_of_ops]
+        assert isinstance(unp.to_dense(numpy_ops), np.ndarray)
+        assert isinstance(unp.to_dense(normal_array), np.ndarray)
+        assert isinstance(unp.to_dense(op_arr), np.ndarray)
+        assert isinstance(unp.to_dense(single_op), np.ndarray)
+        assert isinstance(unp.to_dense(list_of_arrays), np.ndarray)
 
-    def test_to_array_BCOO(self):
+    def test_to_dense_BCOO(self):
         """Convert BCOO type to array."""
 
         bcoo = jsparse.BCOO.fromdense(np.array([[0.0, 1.0], [1.0, 0.0]]))
-        out = to_array(bcoo)
-        self.assertTrue(isinstance(out, Array))
+        out = unp.to_dense(bcoo)
+        self.assertTrue(isinstance(out, jnp.ndarray))
         self.assertAllClose(out, np.array([[0.0, 1.0], [1.0, 0.0]]))
 
 
-class Test_to_csr(QiskitDynamicsTestCase):
-    """Tests for to_csr."""
+class Test_to_sparse(NumpyTestBase):
+    """Tests for to_sparse."""
 
     def test_None_to_None(self):
         """Test that None input returns None."""
-        self.assertTrue(to_csr(None) is None)
+        self.assertTrue(unp.to_sparse(None) is None)
 
-    def test_to_csr_Operator(self):
-        """Tests for to_csr with a single operator"""
+    def test_to_sparse_Operator(self):
+        """Tests for to_sparse with a single operator"""
         op = Operator.from_label("X")
-        self.assertAllCloseSparse(to_csr(op), csr_matrix([[0, 1], [1, 0]]))
+        self.assertAllCloseSparse(unp.to_sparse(op), csr_matrix([[0, 1], [1, 0]]))
 
-    def test_to_csr_nparray(self):
-        """Tests for to_csr with a single numpy array"""
+    def test_to_sparse_nparray(self):
+        """Tests for to_sparse with a single numpy array"""
         nparray = np.array([[0, 1], [1, 0]])
-        self.assertAllCloseSparse(to_csr(nparray), csr_matrix(nparray))
+        self.assertAllCloseSparse(unp.to_sparse(nparray), csr_matrix(nparray))
 
-    def test_to_csr_array(self):
-        """Tests for to_csr with a single sparse matrix"""
+    def test_to_sparse_array(self):
+        """Tests for to_sparse with a single sparse matrix"""
         op = Operator.from_label("X")
         spm = csr_matrix(op)
-        ar = Array(op)
-        self.assertAllCloseSparse(to_csr(ar), spm)
+        ar = unp.asarray(op)
+        self.assertAllCloseSparse(unp.to_sparse(ar), spm)
 
-    def test_to_csr_sparse_matrix(self):
-        """Tests for to_csr with a single sparse matrix"""
+    def test_to_sparse_sparse_matrix(self):
+        """Tests for to_sparse with a single sparse matrix"""
         op = Operator.from_label("X")
         spm = csr_matrix(op)
-        self.assertAllCloseSparse(to_csr(spm), spm)
+        self.assertAllCloseSparse(unp.to_sparse(spm), spm)
 
-    def test_to_csr_Operator_list(self):
-        """Tests for to_csr with a list of operators"""
+    def test_to_sparse_Operator_list(self):
+        """Tests for to_sparse with a list of operators"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
-        self.assertAllCloseSparse(to_csr(op_arr), sparse_matrices)
+        self.assertAllCloseSparse(unp.to_sparse(op_arr), sparse_matrices)
 
-    def test_to_csr_nparray_list(self):
-        """Tests for to_csr with a list of numpy arrays"""
+    def test_to_sparse_nparray_list(self):
+        """Tests for to_sparse with a list of numpy arrays"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
-        nparray_list = [np.array(op) for op in list_of_ops]
+        nparray_list = [unp.asarray(op) for op in list_of_ops]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
-        self.assertAllCloseSparse(to_csr(nparray_list), sparse_matrices)
+        self.assertAllCloseSparse(unp.to_sparse(nparray_list), sparse_matrices)
 
-    def test_to_csr_sparse_matrix_list(self):
-        """Tests for to_csr with a list of sparse matrices"""
+    def test_to_sparse_sparse_matrix_list(self):
+        """Tests for to_sparse with a list of sparse matrices"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
-        self.assertAllCloseSparse(to_csr(sparse_matrices), sparse_matrices)
+        self.assertAllCloseSparse(unp.to_sparse(sparse_matrices), sparse_matrices)
 
-    def test_to_csr_types(self):
-        """Type conversion tests for to_csr"""
+    def test_to_sparse_types(self):
+        """Type conversion tests for to_sparse"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
-        numpy_ops = np.array(list_of_ops)
-        normal_array = Array(np.array(list_of_ops))
+        normal_array = unp.asarray(list_of_ops)
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         single_op = op_arr[0]
-        list_of_arrays = [Array(op) for op in list_of_ops]
+        list_of_arrays = [unp.asarray(op) for op in list_of_ops]
         single_array = list_of_arrays[0]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
-        assert isinstance(to_csr(normal_array)[0], csr_matrix)
-        assert isinstance(to_csr(numpy_ops)[0], csr_matrix)
-        assert isinstance(to_csr(op_arr)[0], csr_matrix)
-        assert isinstance(to_csr(single_op), csr_matrix)
-        assert isinstance(to_csr(single_array), csr_matrix)
-        assert isinstance(to_csr(list_of_arrays[0]), csr_matrix)
-        assert isinstance(to_csr(sparse_matrices), Iterable)
-        assert isinstance(to_csr(sparse_matrices)[0], csr_matrix)
+        assert isinstance(unp.to_sparse(normal_array)[0], csr_matrix)
+        assert isinstance(unp.to_sparse(op_arr)[0], csr_matrix)
+        assert isinstance(unp.to_sparse(single_op), csr_matrix)
+        assert isinstance(unp.to_sparse(single_array), csr_matrix)
+        assert isinstance(unp.to_sparse(list_of_arrays[0]), csr_matrix)
+        assert isinstance(unp.to_sparse(sparse_matrices), Iterable)
+        assert isinstance(unp.to_sparse(sparse_matrices)[0], csr_matrix)
 
 
-class Testto_BCOO(QiskitDynamicsTestCase, TestJaxBase):
+class Test_to_BCOO(JAXTestBase):
     """Test the to_BCOO function."""
 
     def test_None_to_None(self):
@@ -521,29 +521,29 @@ class Test_to_numeric_matrix_type(QiskitDynamicsTestCase):
     def test_to_numeric_matrix_type(self):
         """Tests for to_numeric_matrix_type"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
-        normal_array = Array(np.array(list_of_ops))
-        list_of_arrays = [Array(op) for op in list_of_ops]
+        normal_array = unp.asarray(list_of_ops)
+        list_of_arrays = [unp.asarray(op) for op in list_of_ops]
         op_arr = [Operator.from_label(s) for s in "XYZ"]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
-        self.assertAllClose(to_numeric_matrix_type(list_of_ops), normal_array)
-        self.assertAllClose(to_numeric_matrix_type(list_of_arrays), normal_array)
-        self.assertAllClose(to_numeric_matrix_type(op_arr), list_of_arrays)
+        self.assertAllClose(unp.to_numeric_matrix_type(list_of_ops), normal_array)
+        self.assertAllClose(unp.to_numeric_matrix_type(list_of_arrays), normal_array)
+        self.assertAllClose(unp.to_numeric_matrix_type(op_arr), list_of_arrays)
         for i in range(3):
             self.assertAllCloseSparse(
-                to_numeric_matrix_type(sparse_matrices)[i], sparse_matrices[i]
+                unp.to_numeric_matrix_type(sparse_matrices)[i], sparse_matrices[i]
             )
 
 
-class Test_to_numeric_matrix_type_Jax(QiskitDynamicsTestCase, TestJaxBase):
+class Test_to_numeric_matrix_type_Jax(JAXTestBase):
     """Test to_numeric_matrix_type"""
 
     def test_to_numeric_matrix_type(self):
         """Tests for to_numeric_matrix_type"""
         list_of_ops = [[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]]
-        bcoo = jsparse.BCOO.fromdense(to_array(list_of_ops))
-        bcoo2 = to_numeric_matrix_type(bcoo)
+        bcoo = jsparse.BCOO.fromdense(unp.to_dense(list_of_ops))
+        bcoo2 = unp.to_numeric_matrix_type(bcoo)
         self.assertTrue(type(bcoo2).__name__ == "BCOO")
-        self.assertAllClose(bcoo.todense(), bcoo2.todense())
+        self.assertAllClose(bcoo.todense(), unp.to_dense(bcoo2))
 
 
 class TestTypeUtilsQutip(QiskitDynamicsTestCase, QutipTestBase):
@@ -558,5 +558,5 @@ class TestTypeUtilsQutip(QiskitDynamicsTestCase, QutipTestBase):
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
         qutip_qobj = [Qobj(op) for op in list_of_ops]
         self.assertAllCloseSparse(to_numeric_matrix_type(qutip_qobj)[0], sparse_matrices[0])
-        self.assertAllCloseSparse(to_csr(qutip_qobj)[0], sparse_matrices[0])
+        self.assertAllCloseSparse(unp.to_sparse(qutip_qobj)[0], sparse_matrices[0])
         self.assertAllClose(to_array(qutip_qobj)[0], normal_array[0])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Updating Model folders

- ~generator_model~
- ~hamiltonian_model~
- ~lindblad_model~
- ~operator_collections~
- ~rotating_frame~
- ~rotating_wave_approximation~

### Details and comments

[TODO]
- check if we can deprecate to_numeric_matrix_type

[Points to discuss]

### 1. The necessity of `to_numeric_matrix_type`
   - Can its role be effectively covered by `asarray`?

### 2. Registering `list` type to alias
   - The `list` type will be used for `List[sparse_matrix]`, and it may be replaced if a new class like `CsrMatrixList` is defined. However, it's unclear where this type is used. Conversion to `CsrMatrixList` or `BCOOList` is necessary in certain places. In dynamic, dealing with `List[Sparse matrix]`, and it's uncertain whether registering `CsrMatrixList` to `scipy_sparse` and custom functions in `scipy_sparse` can adequately cover the role of `List[Sparse matrix]`. (Ref: [Link](https://github.com/Qiskit-Extensions/qiskit-dynamics/pull/286#pullrequestreview-1718070094))

### 3. Replacing `Array.default_backend() == jax`
   - `Array` will be deprecated, and an alternative method needs consideration. The current code implementation involves checking if `operators` is related to `jax` using `is_operators_jax = any(lib in ("jax", "jax_sparse") for lib in DYNAMICS_NUMPY_ALIAS.infer_libs(operators))`. Functionalizing this process is desired.

### 4. `isinstance(, ArrayLike)`
   - Encounter TypeError: Subscripted generics cannot be used with class and instance checks. The aim is to use this if possible.

### 5. `unp.to_dense`
   - Assuming that Jax-related functions or classes can be used only when using `jnp.array()`. For instance, the difference between `to_BCOO` and `unp.to_sparse`. `to_BCOO` covers BCOO even with any array, while `unp.to_sparse` only changes to BCOO if `jnp.array()` is used.

### 6. `Operator.from_label()`
   - Similar to the points above. `Operator.from_label().data` supports `np.array()`, and if using the Jax model, `Operator.from_label()` is utilized as `jnp.array(Operator.from_label())`.



