### PR TITLE
fix frozen module warnings in docs build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ deps =
     jax
     jaxlib
     diffrax
+setenv =
+    PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =
   sphinx-build -j auto -W -T --keep-going {posargs} docs/ docs/_build/html
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Sets environment variable in `tox` docs build command to suppress/ignore frozen module warnings. Interestingly this also eliminates the complex -> real casting warning coming from JAX's `tensordot` (which I will choose to not think about deeply for now :) ). Thanks to @wshanks for help.

### Details and comments


