### PR TITLE
Implement DynamicsBackend.solve function and unit test

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -51,7 +51,6 @@ from qiskit.quantum_info.states.quantum_state import QuantumState
 from qiskit_dynamics import RotatingFrame
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.solvers.solver_classes import Solver
-from qiskit_dynamics.signals import Signal
 
 from .dynamics_job import DynamicsJob
 from .backend_utils import (
@@ -372,9 +371,7 @@ class DynamicsBackend(BackendV2):
             OdeResult: object with formatted output types.
         """
         if validate:
-            _validate_run_input(
-                solve_input, accepted_types=(QuantumCircuit, Schedule, ScheduleBlock)
-            )
+            _validate_run_input(solve_input)
         schedules, _ = _to_schedule_list(solve_input, backend=self)
         solver_results = self.options.solver.solve(
             t_span=t_span,
@@ -918,15 +915,15 @@ def default_experiment_result_function(
         raise QiskitError(f"meas_level=={backend.options.meas_level} not implemented.")
 
 
-def _validate_run_input(run_input, accepted_types, accept_list=True):
+def _validate_run_input(run_input, accept_list=True):
     """Raise errors if the run_input is not one of QuantumCircuit, Schedule, ScheduleBlock, or
     a list of these.
     """
     if isinstance(run_input, list) and accept_list:
         # if list apply recursively, but no longer accept lists
         for x in run_input:
-            _validate_run_input(x, accepted_types, accept_list=False)
-    elif not isinstance(run_input, accepted_types):
+            _validate_run_input(x, accept_list=False)
+    elif not isinstance(run_input, (QuantumCircuit, Schedule, ScheduleBlock)):
         caller_func_name = inspect.stack()[1].function
         raise QiskitError(
             f"Input type {type(run_input)} not supported by DynamicsBackend.{caller_func_name}."

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -930,16 +930,17 @@ def default_experiment_result_function(
         raise QiskitError(f"meas_level=={backend.options.meas_level} not implemented.")
 
 
-def _validate_run_input(run_input, accept_list=True):
+def _validate_run_input(run_input, accept_list=True, caller_func_name: str = None):
     """Raise errors if the run_input is not one of QuantumCircuit, Schedule, ScheduleBlock, or
     a list of these.
     """
+    if caller_func_name is None:
+        caller_func_name = inspect.stack()[1].function
     if isinstance(run_input, list) and accept_list:
         # if list apply recursively, but no longer accept lists
         for x in run_input:
-            _validate_run_input(x, accept_list=False)
+            _validate_run_input(x, accept_list=False, caller_func_name=caller_func_name)
     elif not isinstance(run_input, (QuantumCircuit, Schedule, ScheduleBlock)):
-        caller_func_name = inspect.stack()[1].function
         raise QiskitError(
             f"Input type {type(run_input)} not supported by DynamicsBackend.{caller_func_name}."
         )

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -344,20 +344,15 @@ class DynamicsBackend(BackendV2):
 
     def solve(
         self,
+        solve_input: List[Union[QuantumCircuit, Schedule, ScheduleBlock]],
         t_span: Array,
         y0: Optional[Union[Array, QuantumState, BaseOperator]] = None,
-        solve_input: Optional[
-            Union[
-                List[QuantumCircuit],
-                List[Union[Schedule, ScheduleBlock]],
-            ]
-        ] = None,
         convert_results: Optional[bool] = True,
         validate: Optional[bool] = True,
     ) -> Union[OdeResult, List[OdeResult]]:
         """Simulate a list of :class:`~qiskit.circuit.QuantumCircuit`,
-           :class:`~qiskit.pulse.Schedule`, or :class:`~qiskit.pulse.ScheduleBlock` instances and
-           return the ``OdeResult``.
+        :class:`~qiskit.pulse.Schedule`, or :class:`~qiskit.pulse.ScheduleBlock` instances and
+        return the ``OdeResult``.
 
         This method is analogous to :meth:`.Solver.solve`, however it additionally utilizes
         transpilation and the backend configuration to convert

--- a/releasenotes/notes/dynamics-backend-solve-fd42dac884ff80cc.yaml
+++ b/releasenotes/notes/dynamics-backend-solve-fd42dac884ff80cc.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds the :meth:`.DynamicsBackend.solve` function for ODE simulations with arbitrary input types
+    `y0` (`Statevector`, `Operator`, ..), corresponding to the :meth:`.Solver.solve` function of the
+    backends preconfigured :class:`.Solver` member.

--- a/releasenotes/notes/dynamics-backend-solve-fd42dac884ff80cc.yaml
+++ b/releasenotes/notes/dynamics-backend-solve-fd42dac884ff80cc.yaml
@@ -1,6 +1,5 @@
 ---
 features:
   - |
-    Adds the :meth:`.DynamicsBackend.solve` function for ODE simulations with arbitrary input types
-    `y0` (`Statevector`, `Operator`, ..), corresponding to the :meth:`.Solver.solve` function of the
-    backends preconfigured :class:`.Solver` member.
+    Adds the :meth:`.DynamicsBackend.solve` method for running simulations of circuits and schedules
+    for arbitrary input types, and returning the ODE simulation results.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy>=1.17",
     "scipy>=1.4",
     "matplotlib>=3.0",
-    "qiskit-terra<1.0.0",
+    "qiskit<1.0",
     "multiset>=3.0.1",
     "sympy>=1.12",
     "arraylias"

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -23,9 +23,9 @@ from scipy.integrate._ivp.ivp import OdeResult
 from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError, pulse, QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit.circuit.library import XGate, Measure
+from qiskit.circuit.library import XGate, UnitaryGate, Measure
 from qiskit.transpiler import Target, InstructionProperties
-from qiskit.quantum_info import Statevector, DensityMatrix, Operator, Choi
+from qiskit.quantum_info import Statevector, DensityMatrix, Operator, SuperOp
 from qiskit.result.models import ExperimentResult, ExperimentResultData
 from qiskit.providers.models.backendconfiguration import UchannelLO
 from qiskit.providers.backend import QubitProperties
@@ -303,30 +303,40 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         self.assertDictEqual(counts, {"1": 1024})
 
     def test_solve(self):
-        """Test the ODE simulation with different input and y0 types."""
+        """Test the ODE simulation with different input and y0 types using a X pulse."""
+        # create the circuit, pulse schedule and calibrate the gate
+        x_circ0 = QuantumCircuit(1)
+        x_circ0.x(0)
         n_samples = 100
         with pulse.build() as x_sched0:
             pulse.play(pulse.Waveform([1.0] * n_samples), pulse.DriveChannel(0))
-        x_circ0 = QuantumCircuit(1)
-        x_circ0.x(0)
         x_circ0.add_calibration("x", [0], x_sched0)
 
-        y0_variety = [
-            Statevector(np.array([[1.0], [0.0]])),
-            Operator(np.eye(2)),
-            DensityMatrix(QuantumCircuit(1)),
-            Choi(QuantumCircuit(1)),
-            None,
-        ]
+        # create the initial states and expected simulation results
+        expected_unitary = -1.0j * np.array([[0, 1], [1, 0]], dtype=np.complex128)
+        y0_and_expected_results = []
+        for y0_type in [Statevector, Operator, DensityMatrix, SuperOp]:
+            y0 = y0_type(QuantumCircuit(1))
+            expected_result = y0_type(UnitaryGate(expected_unitary))
+            y0_and_expected_results.append((y0, expected_result))
+        # y0=None defaults to Statevector
+        y0_and_expected_results.append(
+            (None, Statevector(QuantumCircuit(1)).evolve(expected_unitary))
+        )
         input_variety = [x_sched0, x_circ0]
-        for solve_input, y0 in product(input_variety, y0_variety):
+
+        # solve for all combinations of input types and initial states
+        for solve_input, (y0, expected_result) in product(input_variety, y0_and_expected_results):
             solver_results = self.simple_backend.solve(
                 t_span=[0, n_samples * self.simple_backend.dt], y0=y0, solve_input=[solve_input]
             )
             if isinstance(solver_results, list):
-                assert all(result.success for result in solver_results)
+                for solver_result in solver_results:
+                    assert solver_result.success
+                    self.assertAllClose(solver_result.y[-1], expected_result, atol=1e-2)
             else:
                 assert solver_results.success
+                self.assertAllClose(solver_result.y[-1], expected_result, atol=1e-2)
 
     def test_pi_pulse_initial_state(self):
         """Test simulation of a pi pulse with a different initial state."""

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -316,6 +316,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             Operator(np.eye(2)),
             DensityMatrix(QuantumCircuit(1)),
             Choi(QuantumCircuit(1)),
+            None,
         ]
         input_variety = [x_sched0, x_circ0]
         for solve_input, y0 in product(input_variety, y0_variety):


### PR DESCRIPTION
### Summary

Add public function `DynamicsBackend.solve` enabling ODE simulation with the preconfigured solver member of the `DynamicsBackend`.

### Details and comments

I opted for the most barebone implementation, basically just mirroring the interface for the `Solver.solve` function with an additional `validate` parameter.

Depending on how sophisticated one wants to implement this function, a variety of extensions could be thought of, adding ease of usage but also complexity.
One possible extension could be (similar to `DynamicsBackend.run`) to optionally use the placement of the Acquire pulses to dynamically figure out the t_span (if measurements are in the schedule / circuit).

Let me know if you want something of that kind to be added.

Closes #288 