### PR TITLE
Depend on qiskit directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy>=1.17",
     "scipy>=1.4",
     "matplotlib>=3.0",
-    "qiskit-terra<1.0.0",
+    "qiskit<1.0",
     "multiset>=3.0.1",
     "sympy>=1.12",
     "arraylias"


### PR DESCRIPTION
### Summary

Currently, `qiskit-dynamics` depends on `qiskit-terra`. Starting in Qiskit 1.0.0 only the `qiskit` package will be published. This PR changes the requirement to use `qiskit` instead of `qiskit-terra`.

### Details and comments

https://github.com/Qiskit/qiskit/pull/11230