### PR TITLE
bugfix: change to f-string

### DIFF
--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -326,7 +326,7 @@ def requires_backend(backend: str) -> Callable:
                 raise DispatchError(
                     f"Array backend '{backend}' required by {descriptor} "
                     "is not installed. Please install the optional "
-                    "library '{backend}'."
+                    f"library '{backend}'."
                 )
 
         # Decorate a function or method


### PR DESCRIPTION
### Summary
Fixed error message to be an F-string. 

Currently, the error reads:
```
"Array backend 'jax' required by function <function jax_odeint at 0x7f9ac9ce4ee0> is not installed. 
Please install the optional library '{backend}'."
```

Fixed to:
```
"Array backend 'jax' required by function <function jax_odeint at 0x7f9ac9ce4ee0> is not installed. 
Please install the optional library 'jax'."
```
