### PR TITLE
RWA arraylias conversion

### DIFF
--- a/qiskit_dynamics/arraylias/alias.py
+++ b/qiskit_dynamics/arraylias/alias.py
@@ -122,6 +122,7 @@ def _numpy_multi_dispatch(*args, path, **kwargs):
 
 
 def _to_dense(x):
+    """Convert an array to dense."""
     libs = DYNAMICS_NUMPY_ALIAS.infer_libs(x)
     if "scipy_sparse" in libs or "jax_sparse" in libs:
         return DYNAMICS_NUMPY.array(x.todense())
@@ -129,6 +130,9 @@ def _to_dense(x):
 
 
 def _to_dense_list(x):
+    """Convert a list of arrays to their corresponding dense version. Assumes input is either a list
+    of scipy sparse, a BCOO array, or numpy/jax array.
+    """
     libs = DYNAMICS_NUMPY_ALIAS.infer_libs(x)
     if "scipy_sparse" in libs:
         return DYNAMICS_NUMPY.array([op.todense() for op in x])

--- a/qiskit_dynamics/arraylias/alias.py
+++ b/qiskit_dynamics/arraylias/alias.py
@@ -127,6 +127,7 @@ def _to_dense(x):
         return DYNAMICS_NUMPY.array(x.todense())
     return x
 
+
 def _to_dense_list(x):
     libs = DYNAMICS_NUMPY_ALIAS.infer_libs(x)
     if "scipy_sparse" in libs:

--- a/qiskit_dynamics/arraylias/alias.py
+++ b/qiskit_dynamics/arraylias/alias.py
@@ -119,3 +119,18 @@ def _numpy_multi_dispatch(*args, path, **kwargs):
     """
     lib = _preferred_lib(*args, **kwargs)
     return DYNAMICS_NUMPY_ALIAS(like=lib, path=path)(*args, **kwargs)
+
+
+def _to_dense(x):
+    libs = DYNAMICS_NUMPY_ALIAS.infer_libs(x)
+    if "scipy_sparse" in libs or "jax_sparse" in libs:
+        return DYNAMICS_NUMPY.array(x.todense())
+    return x
+
+def _to_dense_list(x):
+    libs = DYNAMICS_NUMPY_ALIAS.infer_libs(x)
+    if "scipy_sparse" in libs:
+        return DYNAMICS_NUMPY.array([op.todense() for op in x])
+    elif "jax_sparse" in libs:
+        return x.todense()
+    return x

--- a/qiskit_dynamics/arraylias/register_functions/asarray.py
+++ b/qiskit_dynamics/arraylias/register_functions/asarray.py
@@ -16,6 +16,8 @@
 Registering asarray functions to alias
 """
 
+from typing import Iterable
+
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
 
@@ -33,7 +35,7 @@ def register_asarray(alias):
 
     @alias.register_function(lib="scipy_sparse", path="asarray")
     def _(arr):
-        if issparse(arr) or issparse(arr[0]):
+        if issparse(arr) or (isinstance(arr, Iterable) and issparse(arr[0])):
             return arr
         return csr_matrix(arr)
 

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -19,7 +19,7 @@ from typing import Tuple, Union, List, Optional
 from warnings import warn
 
 from qiskit import QiskitError
-from qiskit_dynamics.arraylias.alias import ArrayLike
+from qiskit_dynamics.arraylias.alias import ArrayLike, _to_dense, _to_dense_list
 from qiskit_dynamics.signals import Signal, SignalList
 from .generator_model import (
     BaseGeneratorModel,
@@ -245,11 +245,11 @@ class LindbladModel(BaseGeneratorModel):
         hamiltonian.in_frame_basis = in_frame_basis
 
         return cls(
-            static_hamiltonian=static_hamiltonian,
-            hamiltonian_operators=hamiltonian_operators,
+            static_hamiltonian=_to_dense(static_hamiltonian),
+            hamiltonian_operators=_to_dense_list(hamiltonian_operators),
             hamiltonian_signals=hamiltonian.signals,
-            static_dissipators=static_dissipators,
-            dissipator_operators=dissipator_operators,
+            static_dissipators=_to_dense_list(static_dissipators),
+            dissipator_operators=_to_dense_list(dissipator_operators),
             dissipator_signals=dissipator_signals,
             rotating_frame=hamiltonian.rotating_frame,
             in_frame_basis=hamiltonian.in_frame_basis,

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -174,6 +174,14 @@ class ScipySparseOperatorCollection:
         self._operators = _to_csr_object_array(operators, decimals)
 
     @property
+    def dim(self) -> int:
+        """The matrix dimension."""
+        if self.static_operator is not None:
+            return self.static_operator.shape[-1]
+        else:
+            return self.operators[0].shape[-1]
+
+    @property
     def static_operator(self) -> Union[None, csr_matrix]:
         """The static part of the operator collection."""
         return self._static_operator

--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -179,7 +179,7 @@ def rotating_wave_approximation(
             signals=rwa_signals,
             rotating_frame=model.rotating_frame,
             in_frame_basis=model.in_frame_basis,
-            array_library=model.array_library
+            array_library=model.array_library,
         )
         if return_signal_map:
             return rwa_model, get_rwa_signals
@@ -234,7 +234,7 @@ def rotating_wave_approximation(
             rotating_frame=model.rotating_frame,
             in_frame_basis=model.in_frame_basis,
             array_library=model.array_library,
-            vectorized=model.vectorized
+            vectorized=model.vectorized,
         )
 
         if return_signal_map:

--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -17,6 +17,9 @@ on Model classes."""
 
 from typing import List, Optional, Union
 import numpy as np
+
+from qiskit_dynamics import DYNAMICS_NUMPY as unp
+from qiskit_dynamics.arraylias.alias import ArrayLike, _to_dense, _to_dense_list
 from qiskit_dynamics.models import (
     BaseGeneratorModel,
     GeneratorModel,
@@ -25,8 +28,6 @@ from qiskit_dynamics.models import (
     RotatingFrame,
 )
 from qiskit_dynamics.signals import SignalSum, Signal, SignalList
-from qiskit_dynamics.array import Array
-from qiskit_dynamics.type_utils import to_array
 
 
 def rotating_wave_approximation(
@@ -147,7 +148,10 @@ def rotating_wave_approximation(
         if model.signals is None and model.operators is not None:
             raise ValueError("Model must have nontrivial signals to perform the RWA.")
 
-        cur_drift = to_array(model._get_static_operator(True))
+        cur_drift = _to_dense(model._operator_collection.static_operator)
+        if isinstance(model, HamiltonianModel) and cur_drift is not None:
+            cur_drift = 1j * cur_drift
+
         if cur_drift is not None:
             cur_drift = cur_drift + frame_shift
             rwa_drift = cur_drift * (abs(frame_freqs) < cutoff_freq).astype(int)
@@ -155,8 +159,12 @@ def rotating_wave_approximation(
         else:
             rwa_drift = None
 
+        operators = _to_dense_list(model._operator_collection.operators)
+        if isinstance(model, HamiltonianModel) and operators is not None:
+            operators = 1j * operators
+
         rwa_operators = get_rwa_operators(
-            to_array(model._get_operators(True)),
+            operators,
             model.signals,
             model.rotating_frame,
             frame_freqs,
@@ -171,7 +179,7 @@ def rotating_wave_approximation(
             signals=rwa_signals,
             rotating_frame=model.rotating_frame,
             in_frame_basis=model.in_frame_basis,
-            evaluation_mode=model.evaluation_mode,
+            array_library=model.array_library
         )
         if return_signal_map:
             return rwa_model, get_rwa_signals
@@ -185,23 +193,23 @@ def rotating_wave_approximation(
             raise ValueError("Model must have nontrivial dissipator signals to perform the RWA.")
 
         # static hamiltonian part
-        cur_drift = to_array(model._get_static_hamiltonian(True)) + frame_shift
+        cur_drift = _to_dense(model._operator_collection.static_hamiltonian) + frame_shift
         rwa_drift = cur_drift * (abs(frame_freqs) < cutoff_freq).astype(int)
         rwa_drift = model.rotating_frame.operator_out_of_frame_basis(rwa_drift)
 
         # static dissipator part
-        cur_static_dis = to_array(model._get_static_dissipators(in_frame_basis=True))
+        cur_static_dis = _to_dense_list(model._operator_collection.static_dissipators)
         rwa_static_dis = None
         if cur_static_dis is not None:
             rwa_static_dis = []
             for op in cur_static_dis:
-                op = Array(op)
+                op = unp.asarray(op)
                 rwa_op = op * (abs(frame_freqs) < cutoff_freq).astype(int)
                 rwa_op = model.rotating_frame.operator_out_of_frame_basis(rwa_op)
                 rwa_static_dis.append(rwa_op)
 
-        cur_ham_ops = to_array(model._get_hamiltonian_operators(in_frame_basis=True))
-        cur_dis_ops = to_array(model._get_dissipator_operators(in_frame_basis=True))
+        cur_ham_ops = _to_dense_list(model._operator_collection.hamiltonian_operators)
+        cur_dis_ops = _to_dense_list(model._operator_collection.dissipator_operators)
 
         cur_ham_sig, cur_dis_sig = model.signals
 
@@ -225,7 +233,8 @@ def rotating_wave_approximation(
             dissipator_signals=rwa_dis_sig,
             rotating_frame=model.rotating_frame,
             in_frame_basis=model.in_frame_basis,
-            evaluation_mode=model.evaluation_mode,
+            array_library=model.array_library,
+            vectorized=model.vectorized
         )
 
         if return_signal_map:
@@ -235,10 +244,10 @@ def rotating_wave_approximation(
 
 
 def get_rwa_operators(
-    current_ops: Array,
+    current_ops: ArrayLike,
     current_sigs: SignalList,
     rotating_frame: RotatingFrame,
-    frame_freqs: Array,
+    frame_freqs: ArrayLike,
     cutoff_freq: float,
 ):
     r"""Given a set of operators as a ``(k,n,n)`` array, a set of frequencies

--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -249,7 +249,7 @@ def get_rwa_operators(
     rotating_frame: RotatingFrame,
     frame_freqs: ArrayLike,
     cutoff_freq: float,
-):
+) -> ArrayLike:
     r"""Given a set of operators as a ``(k,n,n)`` array, a set of frequencies
     :math:`\operatorname{frame_freqs}_{jk} = \operatorname{Im}[-d_j+d_k]` where :math:`d_i` the
     :math:`i^{th}` eigenlvalue of the frame operator :math:`F`, the current signals of a model, and
@@ -297,7 +297,7 @@ def get_rwa_operators(
     )
 
 
-def get_rwa_signals(curr_signal_list: Union[List[Signal], SignalList]):
+def get_rwa_signals(curr_signal_list: Union[List[Signal], SignalList]) -> SignalList:
     """Helper function that converts pre-RWA signals to post-RWA signals.
 
     Args:

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -456,6 +456,7 @@ def to_BCOO(op: Union[Operator, Array, List[Operator], List[Array], spmatrix, "B
 
     return jsparse.BCOO.fromdense(to_array(op).data)
 
+
 #####################################################################################################
 # try to remove this
 def to_numeric_matrix_type(

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -352,6 +352,8 @@ def isinstance_qutip_qobj(obj):
     return False
 
 
+#####################################################################################################
+# try to remove this
 # pylint: disable=too-many-return-statements
 def to_array(op: Union[Operator, Array, List[Operator], List[Array], spmatrix], no_iter=False):
     """Convert an operator or list of operators to an Array.
@@ -396,6 +398,8 @@ def to_array(op: Union[Operator, Array, List[Operator], List[Array], spmatrix], 
         return op
 
 
+#####################################################################################################
+# try to remove this
 # pylint: disable=too-many-return-statements
 def to_csr(
     op: Union[Operator, Array, List[Operator], List[Array], spmatrix], no_iter=False
@@ -429,6 +433,8 @@ def to_csr(
         return csr_matrix(op)
 
 
+#####################################################################################################
+# try to remove this
 @requires_backend("jax")
 def to_BCOO(op: Union[Operator, Array, List[Operator], List[Array], spmatrix, "BCOO"]) -> "BCOO":
     """Convert input op or list of ops to a jax BCOO sparse array.
@@ -450,7 +456,8 @@ def to_BCOO(op: Union[Operator, Array, List[Operator], List[Array], spmatrix, "B
 
     return jsparse.BCOO.fromdense(to_array(op).data)
 
-
+#####################################################################################################
+# try to remove this
 def to_numeric_matrix_type(
     op: Union[Operator, Array, spmatrix, List[Operator], List[Array], List[spmatrix]]
 ):

--- a/test/dynamics/models/test_rotating_wave_approximation.py
+++ b/test/dynamics/models/test_rotating_wave_approximation.py
@@ -9,14 +9,13 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,no-member
 
 """Tests for qiskit_dynamics.models.rotating_wave_approximation"""
 
 from functools import partial
 
 import numpy as np
-from scipy.sparse import issparse
 from qiskit.quantum_info import Operator
 from qiskit_dynamics.signals import Signal, SignalList
 from qiskit_dynamics.models import (
@@ -27,7 +26,7 @@ from qiskit_dynamics.models import (
     rotating_wave_approximation,
 )
 from qiskit_dynamics.models.rotating_wave_approximation import get_rwa_operators
-from ..common import test_array_backends, QiskitDynamicsTestCase, TestJaxBase
+from ..common import test_array_backends
 
 
 @partial(test_array_backends, array_libraries=["numpy", "jax", "jax_sparse", "scipy_sparse"])
@@ -35,6 +34,7 @@ class TestRotatingWaveApproximation:
     """Tests the rotating_wave_approximation function."""
 
     def setUp(self):
+        """Build simple model."""
         self.v = 5.0
         self.r = 0.1
         static_operator = 2 * np.pi * self.v * Operator.from_label("Z") / 2
@@ -46,7 +46,7 @@ class TestRotatingWaveApproximation:
             operators=operators,
             signals=signals,
             rotating_frame=np.diag(static_operator),
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
     def test_generator_model_rwa_with_frame(self):
@@ -67,13 +67,13 @@ class TestRotatingWaveApproximation:
         )
         GM2 = rotating_wave_approximation(GM, 1 / 2 / np.pi)
         self.assertAllClose(GM2.signals(0), [-1, -1, 3, 1, -2, -1])
-        
-        val = GM2(0.)
+
+        val = GM2(0.0)
         self.assertArrayType(val)
         self.assertAllClose(
             val, [[0.25 - 4.0j, -0.25 - 0.646447j], [-0.25 - 1.35355j, -0.25 - 2.0j]], rtol=1e-5
         )
-        val = GM2(1.)
+        val = GM2(1.0)
         self.assertArrayType(val)
         self.assertAllClose(
             val,
@@ -88,7 +88,7 @@ class TestRotatingWaveApproximation:
         """Test analytic RWA with a frame operator with model in frame basis."""
         frame_op = np.array([[4j, 1j], [1j, 2j]])
         sigs = SignalList([Signal(1 + 1j * k, k / 3, np.pi / 2 * k) for k in range(1, 4)])
-        self.assertAllClose(sigs(0.), np.array([-1, -1, 3]))
+        self.assertAllClose(sigs(0.0), np.array([-1, -1, 3]))
         ops = np.array([[[0, 1], [1, 0]], [[0, -1j], [1j, 0]], [[1, 0], [0, -1]]])
 
         GM = GeneratorModel(
@@ -97,16 +97,16 @@ class TestRotatingWaveApproximation:
             signals=sigs,
             rotating_frame=frame_op,
             in_frame_basis=True,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
         rotating_frame = GM.rotating_frame
-        val = GM(0.)
+        val = GM(0.0)
         self.assertArrayType(val)
         self.assertAllClose(
             val,
             rotating_frame.operator_into_frame_basis(np.array([[3 - 4j, -1], [-1 - 2j, -3 - 2j]])),
         )
-        val = GM(1.)
+        val = GM(1.0)
         self.assertArrayType(val)
         self.assertAllClose(
             val,
@@ -119,7 +119,7 @@ class TestRotatingWaveApproximation:
         )
         GM2 = rotating_wave_approximation(GM, 1 / 2 / np.pi)
         self.assertAllClose(GM2.signals(0), [-1, -1, 3, 1, -2, -1])
-        val = GM2(0.)
+        val = GM2(0.0)
         self.assertArrayType(val)
         self.assertAllClose(
             val,
@@ -128,7 +128,7 @@ class TestRotatingWaveApproximation:
             ),
             rtol=1e-5,
         )
-        val = GM2(1.)
+        val = GM2(1.0)
         self.assertArrayType(val)
         self.assertAllClose(
             val,
@@ -149,7 +149,9 @@ class TestRotatingWaveApproximation:
         ops = np.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
         dft = np.ones((2, 2))
-        GM = GeneratorModel(static_operator=dft, operators=ops, signals=sigs, array_library=self.array_library())
+        GM = GeneratorModel(
+            static_operator=dft, operators=ops, signals=sigs, array_library=self.array_library()
+        )
         GMP = rotating_wave_approximation(GM, 2)
         self.assertArrayType(GMP._operator_collection.static_operator)
         self.assertAllClose(GMP._operator_collection.static_operator, np.ones((2, 2)))
@@ -163,7 +165,9 @@ class TestRotatingWaveApproximation:
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
 
         # test without static_operator
-        GM = GeneratorModel(static_operator=None, operators=ops, signals=sigs, array_library=self.array_library())
+        GM = GeneratorModel(
+            static_operator=None, operators=ops, signals=sigs, array_library=self.array_library()
+        )
         GMP = rotating_wave_approximation(GM, 2)
         self.assertTrue(GMP.static_operator is None)
         post_rwa_ops = np.array([1, 0, 1, 0, 0, 0, 0, 0]).reshape((8, 1, 1)) * np.ones((8, 2, 2))
@@ -179,10 +183,10 @@ class TestRotatingWaveApproximation:
             operators=None,
             signals=None,
             rotating_frame=frame_op,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
         GM2 = rotating_wave_approximation(GM, 1.0)
-        val = GM2(0.)
+        val = GM2(0.0)
         self.assertArrayType(val)
         self.assertAllClose(val, np.array([[3.0, 0], [0, 2.0]]))
 
@@ -193,7 +197,7 @@ class TestRotatingWaveApproximation:
         model = LindbladModel(
             static_hamiltonian=np.array([[3.0, 1], [1, 2.0]]) + np.diag(frame_op),
             rotating_frame=frame_op,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
         rwa_model = rotating_wave_approximation(model, 1.0)
         ham = np.array([[3.0, 0], [0, 2.0]])
@@ -214,7 +218,7 @@ class TestRotatingWaveApproximation:
             static_hamiltonian=U @ np.array([[3.0, 1], [1, 2.0]]) @ Uadj + frame_op,
             rotating_frame=frame_op,
             in_frame_basis=True,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
         rwa_model = rotating_wave_approximation(model, 0.99)
         # flipped due to eigenvalue ordering
@@ -248,10 +252,12 @@ class TestRotatingWaveApproximation:
             hamiltonian=self.classic_hamiltonian,
             dissipator_operators=random_diss,
             dissipator_signals=[1.0] * 3,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
         lindblad_model2 = LindbladModel.from_hamiltonian(
-            hamiltonian=self.classic_hamiltonian, static_dissipators=random_diss, array_library=self.array_library()
+            hamiltonian=self.classic_hamiltonian,
+            static_dissipators=random_diss,
+            array_library=self.array_library(),
         )
 
         rwa_lindblad_model1 = rotating_wave_approximation(lindblad_model1, cutoff_freq=self.v)
@@ -271,7 +277,13 @@ class TestRotatingWaveApproximation:
         ops = np.ones((4, 2, 2))
         sigs = [Signal(1, 0), Signal(1, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
         dft = np.ones((2, 2))
-        GM = GeneratorModel(operators=ops, signals=sigs, static_operator=dft, rotating_frame=None, array_library=self.array_library())
+        GM = GeneratorModel(
+            operators=ops,
+            signals=sigs,
+            static_operator=dft,
+            rotating_frame=None,
+            array_library=self.array_library(),
+        )
         f = rotating_wave_approximation(GM, 100, return_signal_map=True)[1]
         vals = f(sigs).complex_value(3)
         self.assertAllClose(vals[:4], GM.signals.complex_value(3))
@@ -301,7 +313,7 @@ class TestRotatingWaveApproximation:
             hamiltonian_signals=sigs,
             dissipator_operators=ops,
             dissipator_signals=sigs,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
         f = rotating_wave_approximation(LM, 100, return_signal_map=True)[1]
         rwa_ham_sig, rwa_dis_sig = f((sigs, sigs))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Converting `rotating_wave_approximation.py` to use arraylias.

I ended up adding the helper functions `_to_dense` and `_to_dense_list` in `arraylias/alias.py` as the `to_array` method had been being used in to convert everything to dense, and we need something analogous. 


### Details and comments

tests that need to be run before merge:

test.dynamics.models (whole folder)
test.dynamics.arraylias (whole folder)
test.dynamics.signals (whole folder)
test.dynamics.pulse (whole folder)
