### PR TITLE
fix `sub_dims` bug in `_get_iq_data`

### DIFF
--- a/qiskit_dynamics/backend/backend_utils.py
+++ b/qiskit_dynamics/backend/backend_utils.py
@@ -234,7 +234,7 @@ def _get_iq_data(
         QiskitError: If number of centers and levels don't match.
     """
     rng = np.random.default_rng(seed)
-    subsystem_dims = state.dims()
+    subsystem_dims = [dim for dim in state.dims() if dim != 1]
     probabilities = state.probabilities()
     probabilities_tensor = probabilities.reshape(list(reversed(subsystem_dims)))
 

--- a/test/dynamics/backend/test_backend_utils.py
+++ b/test/dynamics/backend/test_backend_utils.py
@@ -281,7 +281,7 @@ class Test_get_iq_data(QiskitDynamicsTestCase):
         self.assertDictEqual(counts, {"0": 100})
 
     def test_multi_qubit_predict(self):
-        """Multi_qubit predict test case."""
+        """Multi qubit predict test case."""
         iq_data = _get_iq_data(
             state=Statevector(np.array([0.5, 1, 0, 0]) / np.sqrt(1.25)),
             measurement_subsystems=[0, 1],
@@ -297,8 +297,25 @@ class Test_get_iq_data(QiskitDynamicsTestCase):
         self.assertDictEqual(counts0, {"0": 74, "1": 26})
         self.assertDictEqual(counts1, {"1": 100})
 
+    def test_multi_qubit_with_1d_subsystem(self):
+        """Multi qubit with 1d (trivial) subsystems."""
+        iq_data = _get_iq_data(
+            state=Statevector(np.array([0.5, 1, 0, 0]) / np.sqrt(1.25), dims=(1, 1, 2, 2, 1, 1)),
+            measurement_subsystems=[0, 1],
+            iq_centers=[[(1, 0), (-1, 0)], [(1, 0), (-1, 0)]],
+            iq_width=0.1,
+            shots=100,
+            memory_slot_indices=[0, 1],
+            seed=83248,
+        )
+
+        counts0 = self.iq_to_counts(iq_data[:, 0, :])
+        counts1 = self.iq_to_counts(iq_data[:, 1, :])
+        self.assertDictEqual(counts0, {"0": 74, "1": 26})
+        self.assertDictEqual(counts1, {"1": 100})
+
     def test_mixed_subsystem_predict(self):
-        """Multi_qubit predict test case."""
+        """Multi qubit predict test case."""
         iq_data = _get_iq_data(
             state=Statevector(
                 np.kron(np.array([0.5, 1]), np.array([0, 0, 1])) / np.sqrt(1.25), dims=(3, 2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Backends instantiated using `DynamicsBackend.from_backend` do not work with `meas_level` arg in `DynamicsBackend.run`

### Details and comments
```python
from qiskit import pulse
from qiskit import QuantumCircuit
from qiskit.qobj.utils import MeasLevel
from qiskit_ibm_provider import ibm_provider
from qiskit_dynamics import DynamicsBackend

provider = ibm_provider.IBMProvider()
kyoto = provider.get_backend('ibm_kyoto')
sim_backend = DynamicsBackend.from_backend(kyoto,subsystem_list=[0]) #single qubit backend


qc = QuantumCircuit(1,1)
qc.h(0)
qc.measure([0],[0])

with pulse.build() as h_q0:
    pulse.play(
        pulse.library.Gaussian(duration=256, amp=0.2, sigma=50, name="custom"),
        pulse.DriveChannel(0)
    )
qc.add_calibration("h", qubits=[0], schedule=h_q0)


result = sim_backend.run(qc, meas_level=MeasLevel.KERNELED)

# ValueError: maximum supported dimension for an ndarray is 32, found 127
```

which is raised by [qiskit_dynamics/backend/backend_utils.py:239 --> `probabilities_tensor = probabilities.reshape(list(reversed(subsystem_dims)))`](https://github.com/Qiskit-Extensions/qiskit-dynamics/blob/main/qiskit_dynamics/backend/backend_utils.py#L239)

This PR solves this error by removing all 1d (trivial) systems from the subsystem dims within the `_get_iq_data` function.

More generally, however, `DynamicsBackend.from_backend` must assign a `Target` object with the correct number of qubits to the backend and have the `subsystem_dims` of only the required length.

