### PR TITLE
Update perturbation module to use arraylias

### DIFF
--- a/qiskit_dynamics/models/hamiltonian_model.py
+++ b/qiskit_dynamics/models/hamiltonian_model.py
@@ -172,7 +172,7 @@ def is_hermitian(operator: ArrayLike, tol: Optional[float] = 1e-10) -> bool:
         return is_hermitian(operator.todense())
     elif isinstance(operator, ArrayLike):
         adj = None
-        adj = np.transpose(np.conjugate(operator))
+        adj = unp.transpose(unp.conjugate(operator))
         return np.linalg.norm(adj - operator) < tol
 
     raise QiskitError("is_hermitian got an unexpected type.")

--- a/qiskit_dynamics/perturbation/custom_binary_op.py
+++ b/qiskit_dynamics/perturbation/custom_binary_op.py
@@ -19,7 +19,7 @@ from typing import Optional, List, Tuple, Callable
 
 import numpy as np
 
-from qiskit_dynamics.array import Array
+from qiskit_dynamics.arraylias.alias import _preferred_lib
 
 try:
     import jax.numpy as jnp
@@ -70,7 +70,6 @@ class _CustomBinaryOp:
         binary_op: Callable,
         index_offset: Optional[int] = 0,
         operation_rule_compiled: Optional[bool] = False,
-        backend: Optional[str] = None,
     ):
         """Initialize the binary operation.
 
@@ -80,7 +79,6 @@ class _CustomBinaryOp:
             index_offset: Shift to be added to the indices in operation_rule.
             operation_rule_compiled: True if the operation_rule already corresponds to a
                                      rule that has been compiled to the internal representation.
-            backend: Whether to use JAX or other looping logic.
         """
 
         # store binary op and compile rule to internal format for evaluation
@@ -89,32 +87,22 @@ class _CustomBinaryOp:
         if not operation_rule_compiled:
             operation_rule = _compile_custom_operation_rule(operation_rule, index_offset)
         self._unique_evaluation_pairs, self._linear_combo_rule = operation_rule
-        self._backend = backend or Array.default_backend()
-
-        # establish which version of functions to use
-        if self._backend == "jax":
-            self.__compute_unique_evaluations = lambda A, B: _compute_unique_evaluations_jax(
-                A, B, self._unique_evaluation_pairs, vmap(self._binary_op)
-            )
-            self.__compute_linear_combos = lambda C: _compute_linear_combos_jax(
-                C, self._linear_combo_rule
-            )
-        else:
-            self.__compute_unique_evaluations = lambda A, B: _compute_unique_evaluations(
-                A, B, self._unique_evaluation_pairs, self._binary_op
-            )
-            self.__compute_linear_combos = lambda C: _compute_linear_combos(
-                C, self._linear_combo_rule
-            )
 
     def __call__(self, A: np.ndarray, B: np.ndarray) -> np.ndarray:
         """Evaluate the custom binary operation on arrays A, B."""
-        if self._backend == "jax":
-            A = Array(A).data
-            B = Array(B).data
 
-        unique_evaluations = self.__compute_unique_evaluations(A, B)
-        return self.__compute_linear_combos(unique_evaluations)
+        lib = _preferred_lib(A, B)
+
+        if lib == "jax":
+            unique_evaluations = _compute_unique_evaluations_jax(
+                A, B, self._unique_evaluation_pairs, vmap(self._binary_op)
+            )
+            return _compute_linear_combos_jax(unique_evaluations, self._linear_combo_rule)
+
+        unique_evaluations = _compute_unique_evaluations(
+            A, B, self._unique_evaluation_pairs, self._binary_op
+        )
+        return _compute_linear_combos(unique_evaluations, self._linear_combo_rule)
 
 
 class _CustomMatmul(_CustomBinaryOp):
@@ -125,7 +113,6 @@ class _CustomMatmul(_CustomBinaryOp):
         operation_rule: List,
         index_offset: Optional[int] = 0,
         operation_rule_compiled: Optional[bool] = False,
-        backend: Optional[str] = None,
     ):
         """Initialize."""
 
@@ -135,7 +122,6 @@ class _CustomMatmul(_CustomBinaryOp):
             binary_op=binary_op,
             index_offset=index_offset,
             operation_rule_compiled=operation_rule_compiled,
-            backend=backend,
         )
 
 
@@ -147,7 +133,6 @@ class _CustomMul(_CustomBinaryOp):
         operation_rule: List,
         index_offset: Optional[int] = 0,
         operation_rule_compiled: Optional[bool] = False,
-        backend: Optional[str] = None,
     ):
         """Initialize."""
 
@@ -157,7 +142,6 @@ class _CustomMul(_CustomBinaryOp):
             binary_op=binary_op,
             index_offset=index_offset,
             operation_rule_compiled=operation_rule_compiled,
-            backend=backend,
         )
 
 
@@ -286,11 +270,11 @@ def _compute_linear_combos(
 
 
 def _compute_unique_evaluations_jax(
-    A: np.array,
-    B: np.array,
+    A: jnp.ndarray,
+    B: jnp.ndarray,
     unique_evaluation_pairs: np.array,
     binary_op: Callable,
-) -> np.array:
+) -> jnp.ndarray:
     """JAX version of a single loop step of :meth:`linear_combos`. Note that in this function
     binary_op is assumed to be vectorized."""
     A = jnp.append(A, jnp.zeros((1,) + A[0].shape, dtype=complex), axis=0)
@@ -300,8 +284,8 @@ def _compute_unique_evaluations_jax(
 
 
 def _compute_single_linear_combo_jax(
-    unique_evaluations: np.array, single_combo_rule: Tuple[np.array, np.array]
-) -> np.array:
+    unique_evaluations: jnp.ndarray, single_combo_rule: Tuple[np.array, np.array]
+) -> jnp.ndarray:
     """JAX version of :meth:`unique_products`."""
     coeffs, indices = single_combo_rule
     return jnp.tensordot(coeffs, unique_evaluations[indices], axes=1)

--- a/qiskit_dynamics/perturbation/perturbation_data.py
+++ b/qiskit_dynamics/perturbation/perturbation_data.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from multiset import Multiset
 
 from qiskit import QiskitError
-from qiskit_dynamics.array import Array
 
 
 @dataclass
@@ -38,40 +37,29 @@ class _LabeledData:
         label = self._preprocess_label(label)
 
         if label in self.labels:
-            return self._post_process_item(self.data[self.labels.index(label)])
+            return self.data[self.labels.index(label)]
 
         raise QiskitError("label is not present in self.labels.")
 
     def _preprocess_label(self, label: any) -> any:
         return label
 
-    def _post_process_item(self, item: any) -> any:
-        return item
-
 
 class PowerSeriesData(_LabeledData):
     """Storage container for power series data. Labels are assumed to be ``Multiset`` instances,
-    and data is assumed to be an ``Array``.
+    and data is assumed to be a dense ``ArrayLike``.
     """
 
     def _preprocess_label(self, label: Multiset) -> Multiset:
         """Cast to a Multiset."""
         return Multiset(label)
 
-    def _post_process_item(self, item: Array) -> Array:
-        """Wrap in an Array."""
-        return Array(item, backend=self.data.backend)
-
 
 class DysonLikeData(_LabeledData):
     """Storage container for DysonLike series data. Labels are assumed to be lists of ints,
-    and data is assumed to be an ``Array``.
+    and data is assumed to be a dense ``ArrayLike``.
     """
 
     def _preprocess_label(self, label: list) -> list:
         """Cast to a list."""
         return list(label)
-
-    def _post_process_item(self, item: Array) -> Array:
-        """Wrap in an array."""
-        return Array(item, backend=self.data.backend)

--- a/qiskit_dynamics/solvers/diffrax_solver.py
+++ b/qiskit_dynamics/solvers/diffrax_solver.py
@@ -17,7 +17,7 @@
 Wrapper for diffrax solvers
 """
 
-from typing import Callable, Optional, Union, Tuple, List
+from typing import Callable, Optional
 from scipy.integrate._ivp.ivp import OdeResult
 from qiskit import QiskitError
 

--- a/qiskit_dynamics/solvers/fixed_step_solvers.py
+++ b/qiskit_dynamics/solvers/fixed_step_solvers.py
@@ -15,7 +15,7 @@
 Custom fixed step solvers.
 """
 
-from typing import Callable, Optional, Union, Tuple, List
+from typing import Callable, Optional, Tuple
 from warnings import warn
 import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
@@ -611,7 +611,9 @@ def fixed_step_lmde_solver_parallel_template_jax(
     return trim_t_results(results, t_eval)
 
 
-def get_fixed_step_sizes(t_span: ArrayLike, t_eval: ArrayLike, max_dt: float) -> Tuple[ArrayLike, ArrayLike, ArrayLike]:
+def get_fixed_step_sizes(
+    t_span: ArrayLike, t_eval: ArrayLike, max_dt: float
+) -> Tuple[ArrayLike, ArrayLike, ArrayLike]:
     """Merge ``t_span`` and ``t_eval``, and determine the number of time steps and
     and step sizes (no larger than ``max_dt``) required to fixed-step integrate between
     each time point.

--- a/qiskit_dynamics/solvers/fixed_step_solvers.py
+++ b/qiskit_dynamics/solvers/fixed_step_solvers.py
@@ -23,8 +23,9 @@ from scipy.linalg import expm
 
 from qiskit import QiskitError
 
+from qiskit_dynamics import DYNAMICS_NUMPY as unp
 from qiskit_dynamics.dispatch import requires_backend
-from qiskit_dynamics.array import Array, wrap
+from qiskit_dynamics.arraylias import ArrayLike
 
 try:
     import jax
@@ -37,17 +38,15 @@ except ImportError:
 
 from .solver_utils import merge_t_args, trim_t_results
 from .lanczos import lanczos_expm
-from .lanczos import jax_lanczos_expm as jax_lanczos_expm_
-
-jax_lanczos_expm = wrap(jax_lanczos_expm_)
+from .lanczos import jax_lanczos_expm
 
 
 def RK4_solver(
     rhs: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """Fixed step RK4 solver.
 
@@ -74,21 +73,17 @@ def RK4_solver(
 
         return y + div6 * h * (k1 + 2 * k2 + 2 * k3 + k4)
 
-    # ensure the output of rhs_func is a raw array
-    def wrapped_rhs_func(*args):
-        return Array(rhs(*args)).data
-
     return fixed_step_solver_template(
-        take_step, rhs_func=wrapped_rhs_func, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
+        take_step, rhs_func=rhs, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
     )
 
 
 def scipy_expm_solver(
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
     magnus_order: int = 1,
 ):
     """Fixed-step size matrix exponential based solver implemented with
@@ -109,22 +104,18 @@ def scipy_expm_solver(
     """
     take_step = get_exponential_take_step(magnus_order, expm_func=expm)
 
-    # ensure the output of rhs_func is a raw array
-    def wrapped_rhs_func(*args):
-        return Array(generator(*args)).data
-
     return fixed_step_solver_template(
-        take_step, rhs_func=wrapped_rhs_func, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
+        take_step, rhs_func=generator, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
     )
 
 
 def lanczos_diag_solver(
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
     k_dim: int,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """Fixed-step size matrix exponential based solver implemented using
     lanczos algorithm. Solves the specified problem by taking steps of
@@ -156,19 +147,19 @@ def lanczos_diag_solver(
 @requires_backend("jax")
 def jax_lanczos_diag_solver(
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
     k_dim: int,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """JAX version of lanczos_diag_solver."""
 
     def take_step(generator, t0, y, h):
         eval_time = t0 + (h / 2)
-        return jax_lanczos_expm(generator(eval_time), y, k_dim, h).data
+        return jax_lanczos_expm(generator(eval_time), y, k_dim, h)
 
-    y0 = Array(y0, dtype=complex)
+    y0 = unp.asarray(y0, dtype=complex)
 
     return fixed_step_solver_template_jax(
         take_step, rhs_func=generator, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
@@ -178,10 +169,10 @@ def jax_lanczos_diag_solver(
 @requires_backend("jax")
 def jax_RK4_solver(
     rhs: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """JAX version of RK4_solver.
 
@@ -208,21 +199,18 @@ def jax_RK4_solver(
 
         return y + div6 * h * (k1 + 2 * k2 + 2 * k3 + k4)
 
-    def wrapped_rhs_func(*args):
-        return Array(rhs(*args), backend="jax").data
-
     return fixed_step_solver_template_jax(
-        take_step, rhs_func=wrapped_rhs_func, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
+        take_step, rhs_func=rhs, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
     )
 
 
 @requires_backend("jax")
 def jax_RK4_parallel_solver(
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """Parallel version of :func:`jax_RK4_solver` specialized to LMDEs.
 
@@ -260,10 +248,10 @@ def jax_RK4_parallel_solver(
 @requires_backend("jax")
 def jax_expm_solver(
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
     magnus_order: int = 1,
 ):
     """Fixed-step size matrix exponential based solver implemented with ``jax``.
@@ -283,21 +271,18 @@ def jax_expm_solver(
     """
     take_step = get_exponential_take_step(magnus_order, expm_func=jexpm)
 
-    def wrapped_rhs_func(*args):
-        return Array(generator(*args), backend="jax").data
-
     return fixed_step_solver_template_jax(
-        take_step, rhs_func=wrapped_rhs_func, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
+        take_step, rhs_func=generator, t_span=t_span, y0=y0, max_dt=max_dt, t_eval=t_eval
     )
 
 
 @requires_backend("jax")
 def jax_expm_parallel_solver(
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
     magnus_order: int = 1,
 ):
     """Parallel version of :func:`jax_expm_solver` implemented with JAX parallel operations.
@@ -321,7 +306,7 @@ def jax_expm_parallel_solver(
     )
 
 
-def matrix_commutator(m1: Array, m2: Array) -> Array:
+def matrix_commutator(m1: ArrayLike, m2: ArrayLike) -> ArrayLike:
     """Compute the commutator of two matrices.
 
     Args:
@@ -422,10 +407,10 @@ def get_exponential_take_step(
 def fixed_step_solver_template(
     take_step: Callable,
     rhs_func: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """Helper function for implementing fixed-step solvers supporting both
     ``t_span`` and ``max_dt`` arguments. ``take_step`` is assumed to be a
@@ -456,7 +441,7 @@ def fixed_step_solver_template(
         OdeResult: Results object.
     """
 
-    y0 = Array(y0).data
+    y0 = unp.asarray(y0)
 
     t_list, h_list, n_steps_list = get_fixed_step_sizes(t_span, t_eval, max_dt)
 
@@ -468,7 +453,7 @@ def fixed_step_solver_template(
             y = take_step(rhs_func, inner_t, y, h)
             inner_t = inner_t + h
         ys.append(y)
-    ys = Array(ys)
+    ys = unp.asarray(ys)
 
     results = OdeResult(t=t_list, y=ys)
 
@@ -478,10 +463,10 @@ def fixed_step_solver_template(
 def fixed_step_solver_template_jax(
     take_step: Callable,
     rhs_func: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """This function is the jax control-flow version of
     :meth:`fixed_step_solver_template`. See the documentation of :meth:`fixed_step_solver_template`
@@ -499,7 +484,7 @@ def fixed_step_solver_template_jax(
         OdeResult: Results object.
     """
 
-    y0 = Array(y0).data
+    y0 = jnp.array(y0)
 
     t_list, h_list, n_steps_list = get_fixed_step_sizes(t_span, t_eval, max_dt)
 
@@ -530,7 +515,7 @@ def fixed_step_solver_template_jax(
         xs=(jnp.array(t_list[:-1]), jnp.array(h_list), jnp.array(n_steps_list)),
     )[1]
 
-    ys = Array(jnp.append(jnp.expand_dims(y0, axis=0), ys, axis=0), backend="jax")
+    ys = jnp.append(jnp.expand_dims(y0, axis=0), ys, axis=0)
 
     results = OdeResult(t=t_list, y=ys)
 
@@ -540,10 +525,10 @@ def fixed_step_solver_template_jax(
 def fixed_step_lmde_solver_parallel_template_jax(
     take_step: Callable,
     generator: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     max_dt: float,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ):
     """Parallelized and LMDE specific version of fixed_step_solver_template_jax.
 
@@ -588,11 +573,7 @@ def fixed_step_lmde_solver_parallel_template_jax(
             stacklevel=2,
         )
 
-    # ensure the output of rhs_func is a raw array
-    def wrapped_generator(*args):
-        return Array(generator(*args), backend="jax").data
-
-    y0 = Array(y0).data
+    y0 = jnp.array(y0)
 
     t_list, h_list, n_steps_list = get_fixed_step_sizes(t_span, t_eval, max_dt)
 
@@ -606,7 +587,7 @@ def fixed_step_lmde_solver_parallel_template_jax(
         t_list_locations = np.append(t_list_locations, [t_list_locations[-1] + n_steps])
 
     # compute propagators over each time step in parallel
-    step_propagators = vmap(lambda t, h: take_step(wrapped_generator, t, h))(all_times, all_h)
+    step_propagators = vmap(lambda t, h: take_step(generator, t, h))(all_times, all_h)
 
     # multiply propagators together in parallel
     ys = None
@@ -625,12 +606,12 @@ def fixed_step_lmde_solver_parallel_template_jax(
         intermediate_y = intermediate_props[t_list_locations[1:] - 1] @ y0
         ys = jnp.append(jnp.array([y0]), intermediate_y, axis=0)
 
-    results = OdeResult(t=t_list, y=Array(ys, backend="jax"))
+    results = OdeResult(t=t_list, y=ys)
 
     return trim_t_results(results, t_eval)
 
 
-def get_fixed_step_sizes(t_span: Array, t_eval: Array, max_dt: float) -> Tuple[Array, Array, Array]:
+def get_fixed_step_sizes(t_span: ArrayLike, t_eval: ArrayLike, max_dt: float) -> Tuple[ArrayLike, ArrayLike, ArrayLike]:
     """Merge ``t_span`` and ``t_eval``, and determine the number of time steps and
     and step sizes (no larger than ``max_dt``) required to fixed-step integrate between
     each time point.
@@ -645,8 +626,8 @@ def get_fixed_step_sizes(t_span: Array, t_eval: Array, max_dt: float) -> Tuple[A
         between time points, and list of corresponding number of steps to take between time steps.
     """
     # time args are non-differentiable
-    t_span = Array(t_span, backend="numpy").data
-    max_dt = Array(max_dt, backend="numpy").data
+    t_span = np.array(t_span)
+    max_dt = np.array(max_dt)
     t_list = np.array(merge_t_args(t_span, t_eval))
 
     # set the number of time steps required in each interval so that

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -18,7 +18,6 @@ Wrapper for jax.experimental.ode.odeint
 """
 
 from typing import Callable, Optional
-import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
 
 from qiskit_dynamics import DYNAMICS_NUMPY as unp
@@ -28,7 +27,6 @@ from qiskit_dynamics.dispatch import requires_backend
 from .solver_utils import merge_t_args_jax, trim_t_results_jax
 
 try:
-    import jax.numpy as jnp
     from jax.experimental.ode import odeint
 except ImportError:
     pass

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -17,7 +17,7 @@
 Wrapper for jax.experimental.ode.odeint
 """
 
-from typing import Callable, Optional, Union, Tuple, List
+from typing import Callable, Optional
 import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
 
@@ -61,7 +61,7 @@ def jax_odeint(
     t_direction = unp.sign(unp.asarray(t_list[-1] - t_list[0], dtype=complex))
 
     results = odeint(
-        lambda y, t: rhs(np.real(t_direction * t), y) * t_direction,
+        lambda y, t: rhs(unp.real(t_direction * t), y) * t_direction,
         y0=unp.asarray(y0, dtype=complex),
         t=unp.real(t_direction) * unp.asarray(t_list),
         **kwargs,

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -21,15 +21,15 @@ from typing import Callable, Optional, Union, Tuple, List
 import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
 
+from qiskit_dynamics import DYNAMICS_NUMPY as unp
+from qiskit_dynamics.arraylias import ArrayLike
 from qiskit_dynamics.dispatch import requires_backend
-from qiskit_dynamics.array import Array, wrap
 
 from .solver_utils import merge_t_args_jax, trim_t_results_jax
 
 try:
-    from jax.experimental.ode import odeint as _odeint
-
-    odeint = wrap(_odeint)
+    import jax.numpy as jnp
+    from jax.experimental.ode import odeint
 except ImportError:
     pass
 
@@ -37,9 +37,9 @@ except ImportError:
 @requires_backend("jax")
 def jax_odeint(
     rhs: Callable,
-    t_span: Array,
-    y0: Array,
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_span: ArrayLike,
+    y0: ArrayLike,
+    t_eval: Optional[ArrayLike] = None,
     **kwargs,
 ):
     """Routine for calling `jax.experimental.ode.odeint`
@@ -58,16 +58,15 @@ def jax_odeint(
     t_list = merge_t_args_jax(t_span, t_eval)
 
     # determine direction of integration
-    t_direction = np.sign(Array(t_list[-1] - t_list[0], backend="jax", dtype=complex))
-    rhs = wrap(rhs)
+    t_direction = unp.sign(unp.asarray(t_list[-1] - t_list[0], dtype=complex))
 
     results = odeint(
         lambda y, t: rhs(np.real(t_direction * t), y) * t_direction,
-        y0=Array(y0, dtype=complex),
-        t=np.real(t_direction) * Array(t_list),
+        y0=unp.asarray(y0, dtype=complex),
+        t=unp.real(t_direction) * unp.asarray(t_list),
         **kwargs,
     )
 
-    results = OdeResult(t=t_list, y=Array(results, backend="jax", dtype=complex))
+    results = OdeResult(t=t_list, y=results)
 
     return trim_t_results_jax(results, t_eval)

--- a/qiskit_dynamics/solvers/lanczos.py
+++ b/qiskit_dynamics/solvers/lanczos.py
@@ -20,7 +20,6 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 from qiskit_dynamics.dispatch import requires_backend
-from qiskit_dynamics.array import Array
 
 try:
     import jax.numpy as jnp
@@ -148,7 +147,7 @@ def lanczos_expm(
 
 
 @requires_backend("jax")
-def jax_lanczos_basis(A: Array, y0: Array, k_dim: int):
+def jax_lanczos_basis(A: jnp.ndarray, y0: jnp.ndarray, k_dim: int):
     """JAX version of lanczos_basis."""
 
     data_type = jnp.result_type(A.dtype, y0.dtype)
@@ -204,7 +203,7 @@ def jax_lanczos_basis(A: Array, y0: Array, k_dim: int):
 
 
 @requires_backend("jax")
-def jax_lanczos_eigh(A: Array, y0: Array, k_dim: int):
+def jax_lanczos_eigh(A: jnp.ndarray, y0: jnp.ndarray, k_dim: int):
     """JAX version of lanczos_eigh."""
 
     tridiagonal, q_basis = jax_lanczos_basis(A, y0, k_dim)
@@ -215,8 +214,8 @@ def jax_lanczos_eigh(A: Array, y0: Array, k_dim: int):
 
 @requires_backend("jax")
 def jax_lanczos_expm(
-    A: Array,
-    y0: Array,
+    A: jnp.ndarray,
+    y0: jnp.ndarray,
     k_dim: int,
     scale_factor: Optional[float] = 1,
 ):

--- a/qiskit_dynamics/solvers/scipy_solve_ivp.py
+++ b/qiskit_dynamics/solvers/scipy_solve_ivp.py
@@ -15,14 +15,14 @@
 Wrapper for calling scipy.integrate.solve_ivp.
 """
 
-from typing import Callable, Union, Optional, Tuple, List
+from typing import Callable, Union, Optional
 
 import numpy as np
 from scipy.integrate import solve_ivp, OdeSolver
 from scipy.integrate._ivp.ivp import OdeResult
 
 from qiskit import QiskitError
-from qiskit_dynamics.array import Array
+from qiskit_dynamics.arraylias import ArrayLike
 from ..type_utils import StateTypeConverter
 
 # Supported scipy ODE methods
@@ -33,10 +33,10 @@ SOLVE_IVP_METHODS = COMPLEX_METHODS + REAL_METHODS
 
 def scipy_solve_ivp(
     rhs: Callable,
-    t_span: Array,
-    y0: Array,
+    t_span: ArrayLike,
+    y0: ArrayLike,
     method: Union[str, OdeSolver],
-    t_eval: Optional[Union[Tuple, List, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
     **kwargs,
 ):
     """Routine for calling `scipy.integrate.solve_ivp`.
@@ -84,7 +84,7 @@ def scipy_solve_ivp(
     # convert to the standardized results format
     # solve_ivp returns the states as a 2d array with columns being the states
     results.y = results.y.transpose()
-    results.y = Array([type_converter.inner_to_outer(y) for y in results.y])
+    results.y = np.array([type_converter.inner_to_outer(y) for y in results.y])
 
     return OdeResult(**dict(results))
 

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -668,7 +668,11 @@ class Solver:
                 all_samples[idx, 0 : len(sig.samples)] = np.array(sig.samples)
 
             results_t, results_y = jit_sim_function(
-                unp.asarray(t_span), unp.asarray(y0), unp.asarray(all_samples), unp.asarray(y0_input), y0_cls
+                unp.asarray(t_span),
+                unp.asarray(y0),
+                unp.asarray(all_samples),
+                unp.asarray(y0_input),
+                y0_cls,
             )
             results = OdeResult(t=results_t, y=results_y)
 
@@ -769,7 +773,7 @@ def validate_and_format_initial_state(y0: any, model: Union[HamiltonianModel, Li
     # validate types
     if (y0_cls is SuperOp) and is_lindblad_model_not_vectorized(model):
         raise QiskitError(
-            """Simulating SuperOp for a LindbladModel requires setting vectorized evaluation. 
+            """Simulating SuperOp for a LindbladModel requires setting vectorized evaluation.
             Set vectorized=True when constructing LindbladModel.
             """
         )
@@ -778,11 +782,7 @@ def validate_and_format_initial_state(y0: any, model: Union[HamiltonianModel, Li
     if y0_cls in [DensityMatrix, SuperOp] and isinstance(model, HamiltonianModel):
         y0 = np.eye(model.dim, dtype=complex)
     # if LindbladModel is vectorized and simulating a density matrix, flatten
-    elif (
-        (y0_cls is DensityMatrix)
-        and isinstance(model, LindbladModel)
-        and model.vectorized
-    ):
+    elif (y0_cls is DensityMatrix) and isinstance(model, LindbladModel) and model.vectorized:
         y0 = y0.flatten(order="F")
 
     # validate y0 shape before passing to solve_lmde
@@ -813,9 +813,9 @@ def format_final_states(y, model, y0_input, y0_cls):
     elif y0_cls is SuperOp and isinstance(model, HamiltonianModel):
         # convert to SuperOp and compose
         return (
-            numpy_alias(like=y).einsum("nka,nlb->nklab", y.conj(), y).reshape(
-                y.shape[0], y.shape[1] ** 2, y.shape[1] ** 2
-            )
+            numpy_alias(like=y)
+            .einsum("nka,nlb->nklab", y.conj(), y)
+            .reshape(y.shape[0], y.shape[1] ** 2, y.shape[1] ** 2)
             @ y0_input
         )
     elif (y0_cls is DensityMatrix) and is_lindblad_model_vectorized(model):

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -172,9 +172,9 @@ class Solver:
       frequencies will be used for the RWA.
     * ``dt``: The envelope sample width.
 
-    If configured to simulate Pulse schedules, a JAX-based solver method is chosen, and the model
-    ``array_library`` is JAX compatible, calling :meth:`.Solver.solve` will automatically compile
-    simulation runs.
+    If configured to simulate Pulse schedules, and a JAX-based solver method is chosen when calling
+    :meth:`.Solver.solve`, :meth:`.Solver.solve` will automatically attempt to compile a single
+    function to re-use for all schedule simulations.
 
     The evolution given by the model can be simulated by calling :meth:`.Solver.solve`, which
     calls :func:`.solve_lmde`, and does various automatic

--- a/qiskit_dynamics/solvers/solver_functions.py
+++ b/qiskit_dynamics/solvers/solver_functions.py
@@ -17,12 +17,12 @@ r"""
 Solver functions.
 """
 
-from typing import Optional, Union, Callable, Tuple, List, TypeVar
+from typing import Optional, Union, Callable, Tuple, TypeVar
 from warnings import warn
 
 from scipy.integrate import OdeSolver
 
-from scipy.integrate._ivp.ivp import OdeResult  # pylint: disable=unused-import
+from scipy.integrate._ivp.ivp import OdeResult
 
 from qiskit import QiskitError
 from qiskit_dynamics import DYNAMICS_NUMPY as unp
@@ -132,7 +132,7 @@ def solve_ode(
     method: Optional[Union[str, OdeSolver, DiffraxAbstractSolver]] = "DOP853",
     t_eval: Optional[ArrayLike] = None,
     **kwargs,
-):
+) -> OdeResult:
     r"""General interface for solving Ordinary Differential Equations (ODEs).
 
     ODEs are differential equations of the form
@@ -223,7 +223,7 @@ def solve_lmde(
     method: Optional[Union[str, OdeSolver, DiffraxAbstractSolver]] = "DOP853",
     t_eval: Optional[ArrayLike] = None,
     **kwargs,
-):
+) -> OdeResult:
     r"""General interface for solving Linear Matrix Differential Equations (LMDEs)
     in standard form.
 
@@ -393,10 +393,7 @@ def setup_generator_model_rhs_y0_in_frame_basis(
 
     # if model not specified in frame basis, transform initial state into frame basis
     if not model_in_frame_basis:
-        if (
-            isinstance(generator_model, LindbladModel)
-            and generator_model.vectorized
-        ):
+        if isinstance(generator_model, LindbladModel) and generator_model.vectorized:
             if generator_model.rotating_frame.frame_basis is not None:
                 y0 = generator_model.rotating_frame.vectorized_frame_basis_adjoint @ y0
         elif isinstance(generator_model, LindbladModel):
@@ -438,10 +435,7 @@ def results_y_out_of_frame_basis(
     if y0_ndim == 1:
         results_y = results_y.T
 
-    if (
-        isinstance(generator_model, LindbladModel)
-        and generator_model.vectorized
-    ):
+    if isinstance(generator_model, LindbladModel) and generator_model.vectorized:
         if generator_model.rotating_frame.frame_basis is not None:
             results_y = generator_model.rotating_frame.vectorized_frame_basis @ results_y
     elif isinstance(generator_model, LindbladModel):

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -23,7 +23,7 @@ from scipy.integrate._ivp.ivp import OdeResult
 
 from qiskit import QiskitError
 
-from qiskit_dynamics.array import Array
+from qiskit_dynamics.arraylias import ArrayLike
 from qiskit_dynamics.models import LindbladModel
 
 try:
@@ -44,8 +44,8 @@ def is_lindblad_model_not_vectorized(obj: any) -> bool:
 
 
 def merge_t_args(
-    t_span: Union[List, Tuple, Array], t_eval: Optional[Union[List, Tuple, Array]] = None
-) -> Union[List, Tuple, Array]:
+    t_span: ArrayLike, t_eval: Optional[ArrayLike] = None
+) -> np.ndarray:
     """Merge ``t_span`` and ``t_eval`` into a single array.
 
     Validition is similar to scipy ``solve_ivp``: ``t_eval`` must be contained in ``t_span``, and be
@@ -61,7 +61,7 @@ def merge_t_args(
         t_eval: Time points to include in returned results.
 
     Returns:
-        Union[List, Tuple, Array]: Combined list of times.
+        np.ndarray: Combined list of times.
 
     Raises:
         ValueError: If one of several validation checks fail.
@@ -76,7 +76,7 @@ def merge_t_args(
     t_max = np.max(t_span)
     t_direction = np.sign(t_span[1] - t_span[0])
 
-    t_eval = Array(t_eval, backend="numpy")
+    t_eval = np.array(t_eval)
 
     if t_eval.ndim > 1:
         raise ValueError("t_eval must be 1 dimensional.")
@@ -92,12 +92,12 @@ def merge_t_args(
     # add endpoints
     t_eval = np.append(np.append(t_span[0], t_eval), t_span[1])
 
-    return np.array(t_eval)
+    return t_eval
 
 
 def trim_t_results(
     results: OdeResult,
-    t_eval: Optional[Union[List, Tuple, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ) -> OdeResult:
     """Trim ``OdeResult`` object if ``t_eval is not None``.
 
@@ -116,14 +116,14 @@ def trim_t_results(
 
     # remove endpoints
     results.t = results.t[1:-1]
-    results.y = Array(results.y[1:-1])
+    results.y = results.y[1:-1]
 
     return results
 
 
 def merge_t_args_jax(
-    t_span: Union[List, Tuple, Array], t_eval: Optional[Union[List, Tuple, Array]] = None
-) -> Union[List, Tuple, Array]:
+    t_span: ArrayLike, t_eval: Optional[ArrayLike] = None
+) -> jnp.ndarray:
     """JAX-compilable version of merge_t_args.
 
     Rather than raise errors, sets return values to ``jnp.nan`` to signal errors.
@@ -139,7 +139,7 @@ def merge_t_args_jax(
         t_eval: Time points to include in returned results.
 
     Returns:
-        Union[List, Tuple, Array]: Combined list of times.
+        jnp.ndarray: Combined list of times.
 
     Raises:
         ValueError: If either argument is not one dimensional.
@@ -183,7 +183,7 @@ def merge_t_args_jax(
 
 def trim_t_results_jax(
     results: OdeResult,
-    t_eval: Optional[Union[List, Tuple, Array]] = None,
+    t_eval: Optional[ArrayLike] = None,
 ) -> OdeResult:
     """JAX-compilable version of trim_t_results.
 

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -35,12 +35,12 @@ except ImportError:
 
 def is_lindblad_model_vectorized(obj: any) -> bool:
     """Return True if obj is a vectorized LindbladModel."""
-    return isinstance(obj, LindbladModel) and ("vectorized" in obj.evaluation_mode)
+    return isinstance(obj, LindbladModel) and obj.vectorized
 
 
 def is_lindblad_model_not_vectorized(obj: any) -> bool:
     """Return True if obj is a non-vectorized LindbladModel."""
-    return isinstance(obj, LindbladModel) and ("vectorized" not in obj.evaluation_mode)
+    return isinstance(obj, LindbladModel) and not obj.vectorized
 
 
 def merge_t_args(

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -17,7 +17,7 @@
 Utility functions for solvers.
 """
 
-from typing import Optional, Union, List, Tuple, Callable
+from typing import Optional, List, Tuple, Callable
 import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
 
@@ -43,9 +43,7 @@ def is_lindblad_model_not_vectorized(obj: any) -> bool:
     return isinstance(obj, LindbladModel) and not obj.vectorized
 
 
-def merge_t_args(
-    t_span: ArrayLike, t_eval: Optional[ArrayLike] = None
-) -> np.ndarray:
+def merge_t_args(t_span: ArrayLike, t_eval: Optional[ArrayLike] = None) -> np.ndarray:
     """Merge ``t_span`` and ``t_eval`` into a single array.
 
     Validition is similar to scipy ``solve_ivp``: ``t_eval`` must be contained in ``t_span``, and be
@@ -121,9 +119,7 @@ def trim_t_results(
     return results
 
 
-def merge_t_args_jax(
-    t_span: ArrayLike, t_eval: Optional[ArrayLike] = None
-) -> jnp.ndarray:
+def merge_t_args_jax(t_span: ArrayLike, t_eval: Optional[ArrayLike] = None) -> jnp.ndarray:
     """JAX-compilable version of merge_t_args.
 
     Rather than raise errors, sets return values to ``jnp.nan`` to signal errors.

--- a/releasenotes/notes/solver-class-arraylias-80781bb527c3bf52.yaml
+++ b/releasenotes/notes/solver-class-arraylias-80781bb527c3bf52.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    In conjunction with the change to the ``evaluation_mode`` argument in the model classes, the
+    :class:`.Solver` class has been updated to take the ``array_library`` constructor argument, as
+    well as the ``vectorized`` constructor argument (for use when Lindblad terms are present).
+  - |
+    The logic in :meth:`.Solver.solve` for automatic ``jit`` compiling when using JAX and simulating
+    a list of schedules has been updated to no longer be based on when
+    ``Array.default_backend() == "jax"``. The attempted automatic ``jit`` compiling in this case
+    is now based only when whether either ``method="jax_odeint"``, or ``method`` is a Diffrax
+    integration method. A warning will be raised if the ``array_library`` is not known to be
+    compatible with the compilation routine. (For now, ``"scipy_sparse"`` is the only
+    ``array_library`` not compatible with this routine, however a warning will still be raised if
+    no explicit ``array_library`` is provided, as in this case the JAX-compatibility is unknown.)

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -312,6 +312,12 @@ class DiffraxTestBase(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 import diffrax  # pylint: disable=import-outside-toplevel,unused-import
+            
+            # pylint: disable=import-outside-toplevel
+            import jax
+
+            jax.config.update("jax_enable_x64", True)
+            jax.config.update("jax_platform_name", "cpu")
         except Exception as err:
             raise unittest.SkipTest("Skipping diffrax tests.") from err
 

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -312,7 +312,7 @@ class DiffraxTestBase(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 import diffrax  # pylint: disable=import-outside-toplevel,unused-import
-            
+
             # pylint: disable=import-outside-toplevel
             import jax
 

--- a/test/dynamics/perturbation/test_perturbation_data.py
+++ b/test/dynamics/perturbation/test_perturbation_data.py
@@ -12,11 +12,12 @@
 
 """Tests for perturbation_results.py"""
 
+import numpy as np
+
 from qiskit import QiskitError
 
 from multiset import Multiset
 
-from qiskit_dynamics.array import Array
 from qiskit_dynamics.perturbation.perturbation_data import PowerSeriesData, DysonLikeData
 
 from ..common import QiskitDynamicsTestCase
@@ -27,12 +28,12 @@ class TestDysonLikeData(QiskitDynamicsTestCase):
 
     def test_get_item(self):
         """Test that get_term works."""
-        results = DysonLikeData(data=Array([5, 6, 7]), labels=[[0], [1], [0, 1]])
-        self.assertTrue(results.get_item([1]) == Array(6))
+        results = DysonLikeData(data=np.array([5, 6, 7]), labels=[[0], [1], [0, 1]])
+        self.assertTrue(results.get_item([1]) == 6)
 
     def test_get_item_error(self):
         """Test an error gets raised when a requested term doesn't exist."""
-        results = DysonLikeData(data=Array([5, 6, 7]), labels=[[0], [1], [0, 1]])
+        results = DysonLikeData(data=np.array([5, 6, 7]), labels=[[0], [1], [0, 1]])
         with self.assertRaises(QiskitError):
             # pylint: disable=pointless-statement
             results.get_item([2])
@@ -44,21 +45,21 @@ class TestPowerSeriesData(QiskitDynamicsTestCase):
     def test_get_item(self):
         """Test that get_term works."""
         results = PowerSeriesData(
-            data=Array([5, 6, 7]), labels=[Multiset([0]), Multiset([1]), Multiset([0, 1])]
+            data=np.array([5, 6, 7]), labels=[Multiset([0]), Multiset([1]), Multiset([0, 1])]
         )
-        self.assertTrue(results.get_item(Multiset([1])) == Array(6))
+        self.assertTrue(results.get_item(Multiset([1])) == np.array(6))
 
     def test_automatic_casting(self):
         """Test that get_item works with automatic casting to Multiset."""
         results = PowerSeriesData(
-            data=Array([5, 6, 7]), labels=[Multiset([0]), Multiset([1]), Multiset([0, 1])]
+            data=np.array([5, 6, 7]), labels=[Multiset([0]), Multiset([1]), Multiset([0, 1])]
         )
-        self.assertTrue(results.get_item([1, 0]) == Array(7))
+        self.assertTrue(results.get_item([1, 0]) == np.array(7))
 
     def test_get_item_error(self):
         """Test an error gets raised when a requested term doesn't exist."""
         results = PowerSeriesData(
-            data=Array([5, 6, 7]), labels=[Multiset([0]), Multiset([1]), Multiset([0, 1])]
+            data=np.array([5, 6, 7]), labels=[Multiset([0]), Multiset([1]), Multiset([0, 1])]
         )
         with self.assertRaises(QiskitError):
             # pylint: disable=pointless-statement

--- a/test/dynamics/solvers/test_diffrax_DOP5.py
+++ b/test/dynamics/solvers/test_diffrax_DOP5.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from qiskit_dynamics.solvers.diffrax_solver import diffrax_solver
 
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import JAXTestBase
 
 try:
     import jax.numpy as jnp
@@ -30,7 +30,7 @@ except Exception:
     pass
 
 
-class TestDiffraxDopri5(QiskitDynamicsTestCase, TestJaxBase):
+class TestDiffraxDopri5(JAXTestBase):
     """Test cases for diffrax_solver."""
 
     def setUp(self):

--- a/test/dynamics/solvers/test_fixed_step_solvers.py
+++ b/test/dynamics/solvers/test_fixed_step_solvers.py
@@ -37,10 +37,11 @@ from qiskit_dynamics.solvers.lanczos import (
     jax_lanczos_expm,
 )
 
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import QiskitDynamicsTestCase, JAXTestBase
 
 try:
     from jax.scipy.linalg import expm as jexpm
+    from jax import jit, grad
 # pylint: disable=broad-except
 except Exception:
     pass
@@ -453,8 +454,8 @@ class TestLanczosDiagSolver(TestFixedStepBase):
         self.assertAllClose(result2[-1], expm(gen(0) * t_span[-1]) @ y02)
 
 
-class TestJaxFixedStepBase(TestFixedStepBase, TestJaxBase):
-    """JAX version of TestFixedStepBase, adding JAX setup class TestJaxBase,
+class TestJaxFixedStepBase(TestFixedStepBase, JAXTestBase):
+    """JAX version of TestFixedStepBase, adding JAX setup class JAXTestBase,
     and adding jit/grad test.
     """
 
@@ -468,12 +469,12 @@ class TestJaxFixedStepBase(TestFixedStepBase, TestJaxBase):
             )
             return results.y[-1]
 
-        jit_func = self.jit_wrap(func)
+        jit_func = jit(func)
         output = jit_func(1.0)
         expected_y = self.take_n_steps(self.constant_rhs, t=0.0, y=self.id2, h=0.1, n_steps=10)
         self.assertAllClose(expected_y, output)
 
-        grad_func = self.jit_grad_wrap(func)
+        grad_func = jit(grad(lambda *args: func(*args).real.sum()))
         grad_func(1.0)
 
 

--- a/test/dynamics/solvers/test_fixed_step_solvers.py
+++ b/test/dynamics/solvers/test_fixed_step_solvers.py
@@ -69,9 +69,7 @@ class TestFixedStepBase(ABC, QiskitDynamicsTestCase):
         self.constant_rhs = constant_rhs
 
         Y = np.array([[0.0, -1j], [1j, 0.0]])
-        self.linear_generator = (
-            lambda t: -1j * (X + t * Y)
-        )
+        self.linear_generator = lambda t: -1j * (X + t * Y)
 
         def linear_rhs(t, y=None):
             if y is None:
@@ -99,7 +97,7 @@ class TestFixedStepBase(ABC, QiskitDynamicsTestCase):
         )
 
         def random_generator(t):
-            return unp.sin(t) * rand_ops[0] + (t**5) * rand_ops[1] + unp.exp(t) * rand_ops[2] 
+            return unp.sin(t) * rand_ops[0] + (t**5) * rand_ops[1] + unp.exp(t) * rand_ops[2]
 
         self.random_generator = random_generator
 

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -135,6 +135,7 @@ class TestJaxOdeint(JAXTestBase):
         def func(t_s, t_e):
             results = jax_odeint(self.simple_rhs, t_s, y0, t_eval=t_e, atol=1e-10, rtol=1e-10)
             return results.t, results.y
+
         t, y = jit(func)(t_span, t_eval)
 
         self.assertAllClose(t_eval, t)
@@ -165,7 +166,8 @@ class TestJaxOdeint(JAXTestBase):
             return results.y[-1].real.sum()
 
         self.assertAllClose(
-            jit(grad(lambda a: sim_function(a).real.sum()))(2.0), 4 * (0.5 + (2.0**3 - 1.0**3) / 3)
+            jit(grad(lambda a: sim_function(a).real.sum()))(2.0),
+            4 * (0.5 + (2.0**3 - 1.0**3) / 3),
         )
 
     def test_empty_integration(self):

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -19,17 +19,18 @@ import numpy as np
 
 from qiskit_dynamics.solvers.jax_odeint import jax_odeint
 
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import JAXTestBase
 
 try:
     import jax.numpy as jnp
     from jax.lax import cond
+    from jax import jit, grad
 # pylint: disable=broad-except
 except Exception:
     pass
 
 
-class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
+class TestJaxOdeint(JAXTestBase):
     """Test cases for jax_odeint."""
 
     def setUp(self):
@@ -129,15 +130,12 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
 
         t_span = np.array([0.0, 2.0])
         t_eval = np.array([1.0, 1.5, 1.7])
-        y0 = jnp.array([1.0])
+        y0 = jnp.array([1.0], dtype=complex)
 
         def func(t_s, t_e):
             results = jax_odeint(self.simple_rhs, t_s, y0, t_eval=t_e, atol=1e-10, rtol=1e-10)
-            return results.t.data, results.y.data
-
-        jit_func = self.jit_wrap(func)
-
-        t, y = jit_func(t_span, t_eval)
+            return results.t, results.y
+        t, y = jit(func)(t_span, t_eval)
 
         self.assertAllClose(t_eval, t)
 
@@ -150,7 +148,7 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
         )
         self.assertAllClose(expected_y, y)
 
-        jit_grad_func = self.jit_grad_wrap(lambda a: func(t_span, a)[1][-1])
+        jit_grad_func = jit(grad(lambda a: func(t_span, a)[1][-1].real.sum()))
         out = jit_grad_func(t_eval)
         self.assertAllClose(out, np.array([0.0, 0.0, 1.7**2]))
 
@@ -167,7 +165,7 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
             return results.y[-1].real.sum()
 
         self.assertAllClose(
-            self.jit_grad_wrap(sim_function)(2.0), 4 * (0.5 + (2.0**3 - 1.0**3) / 3)
+            jit(grad(lambda a: sim_function(a).real.sum()))(2.0), 4 * (0.5 + (2.0**3 - 1.0**3) / 3)
         )
 
     def test_empty_integration(self):

--- a/test/dynamics/solvers/test_lanczos.py
+++ b/test/dynamics/solvers/test_lanczos.py
@@ -24,7 +24,7 @@ from qiskit_dynamics.solvers.lanczos import (
     jax_lanczos_eigh,
     jax_lanczos_expm,
 )
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import QiskitDynamicsTestCase, JAXTestBase
 
 
 class TestLanczos(QiskitDynamicsTestCase):
@@ -77,7 +77,7 @@ class TestLanczos(QiskitDynamicsTestCase):
         self.assertAllClose(expAy_s, expAy_l)
 
 
-class TestJaxLanczos(TestLanczos, TestJaxBase):
+class TestJaxLanczos(TestLanczos, JAXTestBase):
     """Tests for jax functions in lanczos.py."""
 
     def setUp(self):

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,no-member
 
 """
 Tests for solver classes module.
@@ -28,12 +28,13 @@ from qiskit_dynamics import Solver, Signal, DiscreteSignal, solve_lmde
 from qiskit_dynamics.models import HamiltonianModel, LindbladModel, rotating_wave_approximation
 from qiskit_dynamics.solvers.solver_classes import organize_signals_to_channels
 
-from ..common import QiskitDynamicsTestCase, test_array_backends, TestJaxBase
+from ..common import QiskitDynamicsTestCase, test_array_backends
 
 try:
     from jax import jit
 except ImportError:
     pass
+
 
 class TestSolverValidation(QiskitDynamicsTestCase):
     """Test validation checks."""
@@ -709,7 +710,7 @@ class TestSolverSimulationJAXTransformations:
             hamiltonian_operators=[X],
             static_hamiltonian=5 * Z,
             rotating_frame=5 * Z,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
     def test_jit_solve(self):
@@ -747,11 +748,12 @@ class TestSolverSimulationJAXTransformations:
 @partial(test_array_backends, array_libraries=["jax"])
 class TestSolverConstructionJAXTransformations:
     """Test construction of Solver within a function to be JAX transformed.."""
+
     def test_transform_through_construction_when_validate_false(self):
         """Test that a function building a Solver can be compiled if validate=False."""
 
-        Z = np.array([[1., 0.], [0., -1.]])
-        X = np.array([[0., 1.], [1., 0.]])
+        Z = np.array([[1.0, 0.0], [0.0, -1.0]])
+        X = np.array([[0.0, 1.0], [1.0, 0.0]])
 
         def func(a):
             solver = Solver(
@@ -759,7 +761,7 @@ class TestSolverConstructionJAXTransformations:
                 hamiltonian_operators=[X],
                 rotating_frame=5 * Z,
                 validate=False,
-                array_library=self.array_library()
+                array_library=self.array_library(),
             )
             yf = solver.solve(
                 t_span=np.array([0.0, 0.1]),
@@ -775,7 +777,6 @@ class TestSolverConstructionJAXTransformations:
         self.jit_grad(func)(1.0)
 
 
-
 @partial(test_array_backends, array_libraries=["numpy", "jax"])
 @ddt
 class TestPulseSimulation:
@@ -788,7 +789,12 @@ class TestPulseSimulation:
         self.X = X
         self.Z = Z
 
-        self.static_ham_solver = Solver(static_hamiltonian=5 * Z, rotating_frame=5 * Z, dt=0.1, array_library=self.array_library())
+        self.static_ham_solver = Solver(
+            static_hamiltonian=5 * Z,
+            rotating_frame=5 * Z,
+            dt=0.1,
+            array_library=self.array_library(),
+        )
 
         self.ham_solver = Solver(
             hamiltonian_operators=[X],
@@ -797,11 +803,15 @@ class TestPulseSimulation:
             hamiltonian_channels=["d0"],
             channel_carrier_freqs={"d0": 5.0},
             dt=0.1,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         self.static_lindblad_solver = Solver(
-            static_dissipators=[0.01 * X], static_hamiltonian=5 * Z, rotating_frame=5 * Z, dt=0.1, array_library=self.array_library()
+            static_dissipators=[0.01 * X],
+            static_hamiltonian=5 * Z,
+            rotating_frame=5 * Z,
+            dt=0.1,
+            array_library=self.array_library(),
         )
 
         self.lindblad_solver = Solver(
@@ -812,7 +822,7 @@ class TestPulseSimulation:
             hamiltonian_channels=["d0"],
             channel_carrier_freqs={"d0": 5.0},
             dt=0.1,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         self.ham_solver_2_channels = Solver(
@@ -822,7 +832,7 @@ class TestPulseSimulation:
             hamiltonian_channels=["d0", "d1"],
             channel_carrier_freqs={"d0": 5.0, "d1": 3.1},
             dt=0.1,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         self.td_lindblad_solver = Solver(
@@ -1004,7 +1014,7 @@ class TestPulseSimulation:
             dissipator_channels=["d1", "d3"],
             channel_carrier_freqs={"d0": 5.0, "d1": 3.1, "d2": 0, "d3": 4.0},
             dt=dt,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         with pulse.build() as schedule:
@@ -1057,7 +1067,7 @@ class TestPulseSimulation:
             channel_carrier_freqs={"d0": 5.0},
             dt=0.1,
             rwa_cutoff_freq=1.5 * 5.0,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         ham_solver = Solver(
@@ -1066,7 +1076,7 @@ class TestPulseSimulation:
             rotating_frame=5 * self.Z,
             rwa_cutoff_freq=1.5 * 5.0,
             rwa_carrier_freqs=[5.0],
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         with pulse.build() as schedule:
@@ -1105,7 +1115,7 @@ class TestPulseSimulation:
             channel_carrier_freqs={"d0": 5.0},
             dt=0.1,
             rwa_cutoff_freq=1.5 * 5.0,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         lindblad_solver = Solver(
@@ -1115,7 +1125,7 @@ class TestPulseSimulation:
             rotating_frame=5 * self.Z,
             rwa_cutoff_freq=1.5 * 5.0,
             rwa_carrier_freqs=[5.0],
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         with pulse.build() as schedule:
@@ -1260,7 +1270,6 @@ class TestPulseSimulation:
             self.assertAllClose(pulse_res.y[-1], signal_res.y[-1], atol=test_tol, rtol=test_tol)
 
 
-
 @partial(test_array_backends, array_libraries=["jax"])
 class TestPulseSimulationJAXPeculiarities:
     """Test class for technical issues of pulse simulation with JAX."""
@@ -1277,7 +1286,7 @@ class TestPulseSimulationJAXPeculiarities:
             hamiltonian_channels=["d0"],
             channel_carrier_freqs={"d0": 5.0},
             dt=0.1,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
     def test_t_eval_t_span_jax_odeint(self):

--- a/test/dynamics/solvers/test_solver_functions.py
+++ b/test/dynamics/solvers/test_solver_functions.py
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,no-member
 
 """Standardized test cases for results of calls to solve_lmde and solve_ode,
 for both variable and fixed-step methods. These tests set up common test cases
@@ -31,7 +31,7 @@ from qiskit_dynamics.models import GeneratorModel, HamiltonianModel
 from qiskit_dynamics.signals import Signal, DiscreteSignal
 from qiskit_dynamics import solve_ode, solve_lmde
 
-from ..common import QiskitDynamicsTestCase, DiffraxTestBase, JAXTestBase, test_array_backends
+from ..common import test_array_backends, DiffraxTestBase
 
 try:
     from diffrax import PIDController, Tsit5, Dopri5
@@ -69,7 +69,9 @@ class TestSolverMethod(ABC):
         self.r = 0.1
         signals = [self.w, Signal(lambda t: 1.0, self.w)]
         operators = [-1j * 2 * np.pi * self.Z / 2, -1j * 2 * np.pi * self.r * self.X / 2]
-        self.simple_model = GeneratorModel(operators=operators, signals=signals, array_library=self.array_library())
+        self.simple_model = GeneratorModel(
+            operators=operators, signals=signals, array_library=self.array_library()
+        )
 
         # construct randomized RHS
         dim = 7
@@ -99,7 +101,7 @@ class TestSolverMethod(ABC):
             signals=[self.pseudo_random_signal],
             static_operator=static_operator,
             rotating_frame=frame_op,
-            array_library=self.array_library()
+            array_library=self.array_library(),
         )
 
         # simulate directly out of frame
@@ -227,12 +229,15 @@ class TestSolverMethodJAX(TestSolverMethod):
 
         def func(a):
             self.pseudo_random_model.signals = [Signal(a, carrier_freq=1.0)]
-            results = self.solve(self.pseudo_random_model, t_span=[0.0, 0.1], y0=self.pseudo_random_y0)
+            results = self.solve(
+                self.pseudo_random_model, t_span=[0.0, 0.1], y0=self.pseudo_random_y0
+            )
             self.pseudo_random_model.signals = None
             return results.y[-1]
 
         # verify we can jit
         from jax import jit
+
         self.assertAllClose(jit(func)(1.0), func(1.0))
 
         # just verify that this runs without error
@@ -257,6 +262,7 @@ class TestRK4(TestSolverMethod):
     @property
     def is_ode_method(self):
         return True
+
 
 @partial(test_array_backends, array_libraries=["jax"])
 class Testjax_RK4(TestSolverMethodJAX):
@@ -314,6 +320,7 @@ class Testscipy_expm(TestSolverMethod):
             **kwargs,
         )
 
+
 @partial(test_array_backends, array_libraries=["numpy"])
 class Testscipy_expm_magnus2(TestSolverMethod):
     """Test class for scipy_expm_solver with magnus_order==2."""
@@ -329,6 +336,7 @@ class Testscipy_expm_magnus2(TestSolverMethod):
             magnus_order=2,
             **kwargs,
         )
+
 
 @partial(test_array_backends, array_libraries=["numpy"])
 class Testscipy_expm_magnus3(TestSolverMethod):
@@ -415,6 +423,7 @@ class Testjax_lanczos_diag(Testlanczos_diag, TestSolverMethodJAX):
             k_dim=max(y0.shape),
             **kwargs,
         )
+
 
 test_array_backends(Testlanczos_diag, array_libraries=["scipy_sparse"])
 

--- a/test/dynamics/solvers/test_solver_functions_interface.py
+++ b/test/dynamics/solvers/test_solver_functions_interface.py
@@ -29,7 +29,7 @@ from qiskit_dynamics.solvers.solver_functions import (
     results_y_out_of_frame_basis,
 )
 
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import QiskitDynamicsTestCase, JAXTestBase
 
 
 class Testsolve_ode_exceptions(QiskitDynamicsTestCase):
@@ -53,7 +53,7 @@ class Testsolve_lmde_exceptions(QiskitDynamicsTestCase):
     def test_lmde_method_non_vectorized_lindblad(self):
         """Test error raising if LMDE method is specified for non-vectorized Lindblad."""
 
-        with self.assertRaisesRegex(QiskitError, "vectorized evaluation"):
+        with self.assertRaisesRegex(QiskitError, "vectorized=True"):
             solve_lmde(
                 self.lindblad_model, t_span=[0.0, 1.0], y0=np.diag([1.0, 0.0]), method="scipy_expm"
             )
@@ -109,7 +109,7 @@ class Testsolve_lmde_exceptions(QiskitDynamicsTestCase):
         in sparse mode."""
 
         model = GeneratorModel(
-            static_operator=np.array([[0.0, 1.0], [1.0, 0.0]]), evaluation_mode="sparse"
+            static_operator=np.array([[0.0, 1.0], [1.0, 0.0]]), array_library="jax_sparse"
         )
 
         with self.assertRaisesRegex(QiskitError, "jax_expm cannot be used"):
@@ -131,7 +131,7 @@ class Testsolve_lmde_exceptions(QiskitDynamicsTestCase):
             )
 
 
-class Testsolve_lmde_exceptionsJAX(QiskitDynamicsTestCase, TestJaxBase):
+class Testsolve_lmde_exceptionsJAX(JAXTestBase):
     """Test solve_lmde exceptions requiring JAX to reach."""
 
     def test_jax_expm_magnus_order_exception(self):
@@ -180,13 +180,42 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
             static_dissipators=[Operator.from_label("Y")],
         )
 
-        self.vec_lindblad_model = self.lindblad_model.copy()
-        self.vec_lindblad_model.evaluation_mode = "dense_vectorized"
+        self.vec_lindblad_model = LindbladModel(
+            hamiltonian_operators=[Operator.from_label("X")],
+            hamiltonian_signals=[Signal(1.0, 5.0)],
+            static_hamiltonian=Operator.from_label("Z"),
+            static_dissipators=[Operator.from_label("Y")],
+            vectorized=True
+        )
 
         self.frame_op = 1.2 * Operator.from_label("X") - 3.132 * Operator.from_label("Y")
         _, U = np.linalg.eigh(self.frame_op)
         self.U = U
         self.Uadj = self.U.conj().transpose()
+
+        self.rf_ham_model = HamiltonianModel(
+            operators=[Operator.from_label("X")],
+            signals=[Signal(1.0, 5.0)],
+            static_operator=Operator.from_label("Z"),
+            rotating_frame=self.frame_op
+        )
+
+        self.rf_lindblad_model = LindbladModel(
+            hamiltonian_operators=[Operator.from_label("X")],
+            hamiltonian_signals=[Signal(1.0, 5.0)],
+            static_hamiltonian=Operator.from_label("Z"),
+            static_dissipators=[Operator.from_label("Y")],
+            rotating_frame=self.frame_op
+        )
+
+        self.rf_vec_lindblad_model = LindbladModel(
+            hamiltonian_operators=[Operator.from_label("X")],
+            hamiltonian_signals=[Signal(1.0, 5.0)],
+            static_hamiltonian=Operator.from_label("Z"),
+            static_dissipators=[Operator.from_label("Y")],
+            rotating_frame=self.frame_op,
+            vectorized=True
+        )
 
     def test_hamiltonian_setup_no_frame(self):
         """Test functions for Hamiltonian with no frame."""
@@ -210,24 +239,21 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
     def test_hamiltonian_setup(self):
         """Test functions for Hamiltonian with frame."""
 
-        ham_model = self.ham_model.copy()
-        ham_model.rotating_frame = self.frame_op
         y0 = np.array([3.43, 1.31])
         gen, rhs, new_y0, model_in_frame_basis = setup_generator_model_rhs_y0_in_frame_basis(
-            ham_model, y0
+            self.rf_ham_model, y0
         )
 
         # check frame parameters
         self.assertFalse(model_in_frame_basis)
         # check that model has been converted to being in frame basis
-        self.assertTrue(ham_model.in_frame_basis)
-        self.assertFalse(self.ham_model.in_frame_basis)
+        self.assertTrue(self.rf_ham_model.in_frame_basis)
 
         self.assertAllClose(self.Uadj @ y0, new_y0)
         t = 231.232
         self.ham_model.in_frame_basis = True
-        self.assertAllClose(gen(t), ham_model(t))
-        self.assertAllClose(rhs(t, y0), ham_model(t, y0))
+        self.assertAllClose(gen(t), self.rf_ham_model(t))
+        self.assertAllClose(rhs(t, y0), self.rf_ham_model(t, y0))
 
     def test_lindblad_setup_no_frame(self):
         """Test functions for LindbladModel with no frame."""
@@ -246,17 +272,14 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
     def test_lindblad_setup(self):
         """Test functions for LindbladModel with frame."""
 
-        lindblad_model = self.lindblad_model.copy()
-        lindblad_model.rotating_frame = self.frame_op
-
         y0 = np.array([[3.43, 1.31], [3.0, 1.23]])
-        _, rhs, new_y0, _ = setup_generator_model_rhs_y0_in_frame_basis(lindblad_model, y0)
+        _, rhs, new_y0, _ = setup_generator_model_rhs_y0_in_frame_basis(self.rf_lindblad_model, y0)
 
         # expect nothing to happen
         self.assertAllClose(self.Uadj @ y0 @ self.U, new_y0)
         t = 231.232
-        self.assertTrue(lindblad_model.in_frame_basis)
-        self.assertAllClose(rhs(t, y0), lindblad_model(t, y0))
+        self.assertTrue(self.rf_lindblad_model.in_frame_basis)
+        self.assertAllClose(rhs(t, y0), self.rf_lindblad_model(t, y0))
 
     def test_vectorized_lindblad_setup_no_frame(self):
         """Test functions for vectorized LindbladModel with no frame."""
@@ -276,18 +299,15 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
     def test_vectorized_lindblad_setup(self):
         """Test functions for vectorized LindbladModel with frame."""
 
-        vec_lindblad_model = self.vec_lindblad_model.copy()
-        vec_lindblad_model.rotating_frame = self.frame_op
-
         y0 = np.array([[3.43, 1.31], [3.0, 1.23]]).flatten()
-        gen, rhs, new_y0, _ = setup_generator_model_rhs_y0_in_frame_basis(vec_lindblad_model, y0)
+        gen, rhs, new_y0, _ = setup_generator_model_rhs_y0_in_frame_basis(self.rf_vec_lindblad_model, y0)
 
         # expect nothing to happen
         self.assertAllClose(np.kron(self.Uadj.conj(), self.Uadj) @ y0, new_y0)
         t = 231.232
-        self.assertTrue(vec_lindblad_model.in_frame_basis)
-        self.assertAllClose(gen(t), vec_lindblad_model(t))
-        self.assertAllClose(rhs(t, y0), vec_lindblad_model(t, y0))
+        self.assertTrue(self.rf_vec_lindblad_model.in_frame_basis)
+        self.assertAllClose(gen(t), self.rf_vec_lindblad_model(t))
+        self.assertAllClose(rhs(t, y0), self.rf_vec_lindblad_model(t, y0))
 
     def test_hamiltonian_results_conversion_no_frame(self):
         """Test hamiltonian results conversion with no frame."""
@@ -305,18 +325,15 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
     def test_hamiltonian_results_conversion(self):
         """Test hamiltonian results conversion."""
 
-        ham_model = self.ham_model.copy()
-        ham_model.rotating_frame = self.frame_op
-
         # test 1d input
         results_y = np.array([[1.0, 23.3], [2.32, 1.232]])
-        output = results_y_out_of_frame_basis(ham_model, results_y, y0_ndim=1)
+        output = results_y_out_of_frame_basis(self.rf_ham_model, results_y, y0_ndim=1)
         expected = [self.U @ y for y in results_y]
         self.assertAllClose(expected, output)
 
         # test 2d input
         results_y = np.array([[[1.0, 23.3], [23, 231j]], [[2.32, 1.232], [1j, 2.0 + 3j]]])
-        output = results_y_out_of_frame_basis(ham_model, results_y, y0_ndim=2)
+        output = results_y_out_of_frame_basis(self.rf_ham_model, results_y, y0_ndim=2)
         expected = [self.U @ y for y in results_y]
         self.assertAllClose(expected, output)
 
@@ -330,11 +347,8 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
     def test_lindblad_results_conversion(self):
         """Test lindblad results conversion."""
 
-        lindblad_model = self.lindblad_model.copy()
-        lindblad_model.rotating_frame = self.frame_op
-
         results_y = np.array([[[1.0, 23.3], [23, 231j]], [[2.32, 1.232], [1j, 2.0 + 3j]]])
-        output = results_y_out_of_frame_basis(lindblad_model, results_y, y0_ndim=2)
+        output = results_y_out_of_frame_basis(self.rf_lindblad_model, results_y, y0_ndim=2)
         expected = [self.U @ y @ self.Uadj for y in results_y]
         self.assertAllClose(expected, output)
 
@@ -359,13 +373,11 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
     def test_vectorized_lindblad_results_conversion(self):
         """Test vectorized lindblad results conversion."""
 
-        vec_lindblad_model = self.vec_lindblad_model.copy()
-        vec_lindblad_model.rotating_frame = self.frame_op
         P = np.kron(self.U.conj(), self.U)
 
         # test 1d input
         results_y = np.array([[1.0, 23.3, 1.23, 0.123], [2.32, 1.232, 1j, 21.2]])
-        output = results_y_out_of_frame_basis(vec_lindblad_model, results_y, y0_ndim=1)
+        output = results_y_out_of_frame_basis(self.rf_vec_lindblad_model, results_y, y0_ndim=1)
         expected = [P @ y for y in results_y]
         self.assertAllClose(expected, output)
 
@@ -376,6 +388,6 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
                 [[2.32, 1.232], [1j, 2.0 + 3j], [2.32, 2.12314], [334.0, 34.3]],
             ]
         )
-        output = results_y_out_of_frame_basis(vec_lindblad_model, results_y, y0_ndim=2)
+        output = results_y_out_of_frame_basis(self.rf_vec_lindblad_model, results_y, y0_ndim=2)
         expected = [P @ y for y in results_y]
         self.assertAllClose(expected, output)

--- a/test/dynamics/solvers/test_solver_functions_interface.py
+++ b/test/dynamics/solvers/test_solver_functions_interface.py
@@ -185,7 +185,7 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
             hamiltonian_signals=[Signal(1.0, 5.0)],
             static_hamiltonian=Operator.from_label("Z"),
             static_dissipators=[Operator.from_label("Y")],
-            vectorized=True
+            vectorized=True,
         )
 
         self.frame_op = 1.2 * Operator.from_label("X") - 3.132 * Operator.from_label("Y")
@@ -197,7 +197,7 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
             operators=[Operator.from_label("X")],
             signals=[Signal(1.0, 5.0)],
             static_operator=Operator.from_label("Z"),
-            rotating_frame=self.frame_op
+            rotating_frame=self.frame_op,
         )
 
         self.rf_lindblad_model = LindbladModel(
@@ -205,7 +205,7 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
             hamiltonian_signals=[Signal(1.0, 5.0)],
             static_hamiltonian=Operator.from_label("Z"),
             static_dissipators=[Operator.from_label("Y")],
-            rotating_frame=self.frame_op
+            rotating_frame=self.frame_op,
         )
 
         self.rf_vec_lindblad_model = LindbladModel(
@@ -214,7 +214,7 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
             static_hamiltonian=Operator.from_label("Z"),
             static_dissipators=[Operator.from_label("Y")],
             rotating_frame=self.frame_op,
-            vectorized=True
+            vectorized=True,
         )
 
     def test_hamiltonian_setup_no_frame(self):
@@ -300,7 +300,9 @@ class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):
         """Test functions for vectorized LindbladModel with frame."""
 
         y0 = np.array([[3.43, 1.31], [3.0, 1.23]]).flatten()
-        gen, rhs, new_y0, _ = setup_generator_model_rhs_y0_in_frame_basis(self.rf_vec_lindblad_model, y0)
+        gen, rhs, new_y0, _ = setup_generator_model_rhs_y0_in_frame_basis(
+            self.rf_vec_lindblad_model, y0
+        )
 
         # expect nothing to happen
         self.assertAllClose(np.kron(self.Uadj.conj(), self.Uadj) @ y0, new_y0)

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -26,7 +26,7 @@ from qiskit_dynamics.solvers.solver_utils import (
     trim_t_results_jax,
 )
 
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import QiskitDynamicsTestCase, JAXTestBase
 
 try:
     import jax.numpy as jnp
@@ -173,7 +173,7 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
         self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))
 
 
-class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
+class TestTimeArgsHandlingJAX(TestTimeArgsHandling, JAXTestBase):
     """Tests for merge_t_args_jax and trim_t_results_jax functions."""
 
     def test_merge_t_args_with_overlap(self):
@@ -219,19 +219,19 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
     def test_merge_t_args_interval_error(self):
         """Test output nan if t_eval not in t_span."""
         out = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([1.5]))
-        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(jnp.isnan(out).all())
         self.assertTrue(out.shape == (3,))
 
     def test_merge_t_args_interval_error_backwards(self):
         """Test output nan if t_eval not in t_span for backwards integration."""
         out = self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-1.5]))
-        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(jnp.isnan(out).all())
         self.assertTrue(out.shape == (3,))
 
     def test_merge_t_args_sort_error(self):
         """Test output nan if t_eval is not correctly sorted."""
         out = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.75, 0.25]))
-        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(jnp.isnan(out).all())
         self.assertTrue(out.shape == (4,))
 
     def test_merge_t_args_sort_error_backwards(self):
@@ -239,7 +239,7 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
         backwards integration.
         """
         out = self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-0.75, -0.25]))
-        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(jnp.isnan(out).all())
         self.assertTrue(out.shape == (4,))
 
     def test_trim_t_results_t0_duplicate(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Integrating perturbation module with arraylias. Depends on #281 

Files to update:
- ~`perturbation_data`~
    - ~tests~
- ~`custom_binary_op`~
    - Using _prefered_lib to infer whether to use JAX versions of functions or not, dropping backend constructor argument
    - ~tests~
- `array_polynomial`
    - tests
- `dyson_magnus`
    - tests
- `solve_lmde_perturbation`
    - Tests

`multiset_utils` and `perturbation_utils` do not contain array operations and therefore don't need to be updated.

### Details and comments

Interface changes:
- The `backend` argument for `_CustomBinaryOp`, which was used to determine whether to use JAX looping logic, has been dropped. `_CustomBinaryOp.__call__` has correspondingly been updated to use `_preferred_lib` to determine whether to use JAX looping logic based on whether one of `A` or `B` is a JAX array.
