### PR TITLE
Changing import path for diffrax AbstractSolver

### DIFF
--- a/qiskit_dynamics/solvers/solver_functions.py
+++ b/qiskit_dynamics/solvers/solver_functions.py
@@ -86,7 +86,7 @@ def _is_jax_method(method: any) -> bool:
 def _is_diffrax_method(method: any) -> bool:
     """Check if method is a diffrax method."""
     try:
-        from diffrax.solver import AbstractSolver
+        from diffrax import AbstractSolver
 
         return isinstance(method, AbstractSolver)
     except ImportError:
@@ -156,7 +156,7 @@ def solve_ode(
     - ``'jax_RK4'``: JAX backend implementation of ``'RK4'`` method.
     - ``'jax_odeint'``: Calls ``jax.experimental.ode.odeint`` variable step solver.
     - ``diffrax.diffeqsolve`` - a JAX solver function, called by passing ``method``
-      as a valid ``diffrax.solver.AbstractSolver`` instance. Requires the ``diffrax`` library.
+      as a valid ``diffrax.AbstractSolver`` instance. Requires the ``diffrax`` library.
 
     Results are returned as a :class:`OdeResult` object.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The latest version of `diffrax` changes the import path of `AbstractSolver`, causing an error to be raised.

### Details and comments

This PR fixes the issue, instead of `from diffrax.solver import AbstractSolver`, we now import as `from diffrax import AbstractSolver`.
