### PR TITLE
Update backend module to use arraylias

### DIFF
--- a/qiskit_dynamics/backend/backend_utils.py
+++ b/qiskit_dynamics/backend/backend_utils.py
@@ -23,13 +23,13 @@ from qiskit import QiskitError
 from qiskit.quantum_info import Statevector, DensityMatrix
 from qiskit.quantum_info.operators.predicates import is_hermitian_matrix
 
-from qiskit_dynamics.array import Array
+
+from qiskit_dynamics.arraylias.alias import ArrayLike, _to_dense
 from qiskit_dynamics.models import HamiltonianModel, LindbladModel
-from qiskit_dynamics.type_utils import to_array
 
 
 def _get_dressed_state_decomposition(
-    operator: np.ndarray, rtol=1e-8, atol=1e-5
+    operator: ArrayLike, rtol=1e-8, atol=1e-5
 ) -> Union[Dict[str, np.ndarray], List[float], Dict[str, float]]:
     """Get the eigenvalues and eigenvectors of a nearly-diagonal hermitian operator, sorted
     according to overlap with the elementary basis.
@@ -92,15 +92,15 @@ def _get_lab_frame_static_hamiltonian(model: Union[HamiltonianModel, LindbladMod
     """
     static_hamiltonian = None
     if isinstance(model, HamiltonianModel):
-        static_hamiltonian = to_array(model.static_operator)
+        static_hamiltonian = _to_dense(model.static_operator)
     else:
-        static_hamiltonian = to_array(model.static_hamiltonian)
+        static_hamiltonian = _to_dense(model.static_hamiltonian)
 
     static_hamiltonian = 1j * model.rotating_frame.generator_out_of_frame(
         t=0.0, operator=-1j * static_hamiltonian
     )
 
-    return Array(static_hamiltonian, backend="numpy").data
+    return np.array(static_hamiltonian)
 
 
 def _get_memory_slot_probabilities(

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -49,7 +49,7 @@ from qiskit.quantum_info.states.quantum_state import QuantumState
 
 
 from qiskit_dynamics import RotatingFrame
-from qiskit_dynamics.array import Array
+from qiskit_dynamics.arraylias.alias import ArrayLike
 from qiskit_dynamics.solvers.solver_classes import Solver
 
 from .dynamics_job import DynamicsJob
@@ -345,8 +345,8 @@ class DynamicsBackend(BackendV2):
     def solve(
         self,
         solve_input: List[Union[QuantumCircuit, Schedule, ScheduleBlock]],
-        t_span: Array,
-        y0: Optional[Union[Array, QuantumState, BaseOperator]] = None,
+        t_span: ArrayLike,
+        y0: Optional[Union[ArrayLike, QuantumState, BaseOperator]] = None,
         convert_results: Optional[bool] = True,
         validate: Optional[bool] = True,
     ) -> Union[OdeResult, List[OdeResult]]:
@@ -593,7 +593,7 @@ class DynamicsBackend(BackendV2):
         cls,
         backend: BackendV1,
         subsystem_list: Optional[List[int]] = None,
-        rotating_frame: Optional[Union[Array, RotatingFrame, str]] = "auto",
+        rotating_frame: Optional[Union[ArrayLike, RotatingFrame, str]] = "auto",
         evaluation_mode: str = "dense",
         rwa_cutoff_freq: Optional[float] = None,
         **options,

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -594,7 +594,8 @@ class DynamicsBackend(BackendV2):
         backend: BackendV1,
         subsystem_list: Optional[List[int]] = None,
         rotating_frame: Optional[Union[ArrayLike, RotatingFrame, str]] = "auto",
-        evaluation_mode: str = "dense",
+        array_library: Optional[str] = None,
+        vectorized: Optional[bool] = False,
         rwa_cutoff_freq: Optional[float] = None,
         **options,
     ) -> "DynamicsBackend":
@@ -649,17 +650,17 @@ class DynamicsBackend(BackendV2):
         constructed :class:`DynamicsBackend`. All other qubits are dropped from the model.
 
         Configuration of the underlying :class:`.Solver` is controlled via the ``rotating_frame``,
-        ``evaluation_mode``, and ``rwa_cutoff_freq`` options. In contrast to :class:`.Solver`
-        initialization, ``rotating_frame`` defaults to the string ``"auto"``, which allows this
-        method to choose the rotating frame based on ``evaluation_mode``:
+        ``array_library``, ``vectorized``, and ``rwa_cutoff_freq`` options. In contrast
+        to :class:`.Solver` initialization, ``rotating_frame`` defaults to the string ``"auto"``,
+        which allows this method to choose the rotating frame based on ``array_library``:
 
-        * If a dense evaluation mode is chosen, the rotating frame will be set to the
+        * If a dense ``array_library`` is chosen, the rotating frame will be set to the
           ``static_hamiltonian`` indicated by the Hamiltonian in ``backend.configuration()``.
-        * If a sparse evaluation mode is chosen, the rotating frame will be set to the diagonal of
+        * If a sparse ``array_library`` is chosen, the rotating frame will be set to the diagonal of
           ``static_hamiltonian``.
 
-        Otherwise the ``rotating_frame``, ``evaluation_mode``, and ``rwa_cutoff_freq`` are passed
-        directly to the :class:`.Solver` initialization.
+        Otherwise the ``rotating_frame``, ``array_library``, ``vectorized``, and
+        ``rwa_cutoff_freq`` are passed directly to the :class:`.Solver` initialization.
 
         Args:
             backend: The ``Backend`` instance to build the :class:`.DynamicsBackend` from.
@@ -671,7 +672,9 @@ class DynamicsBackend(BackendV2):
             subsystem_list: The list of qubits in the backend to include in the model.
             rotating_frame: Rotating frame argument for the internal :class:`.Solver`. Defaults to
                 ``"auto"``, allowing this method to pick a rotating frame.
-            evaluation_mode: Evaluation mode argument for the internal :class:`.Solver`.
+            array_library: Array library with which to store the operators in the :class:`.Solver`.
+            vectorized: If a Lindblad terms are present, whether or not to build the
+                :class:`.Solver` in a vectorized mode.
             rwa_cutoff_freq: Rotating wave approximation argument for the internal :class:`.Solver`.
             **options: Additional options to be applied in construction of the
                 :class:`.DynamicsBackend`.
@@ -762,10 +765,10 @@ class DynamicsBackend(BackendV2):
 
         # build the solver
         if rotating_frame == "auto":
-            if "dense" in evaluation_mode:
-                rotating_frame = static_hamiltonian
-            else:
+            if array_library is not None and "sparse" in array_library:
                 rotating_frame = np.diag(static_hamiltonian)
+            else:
+                rotating_frame = static_hamiltonian
 
         # get time step size
         if backend_target is not None and backend_target.dt is not None:
@@ -781,7 +784,8 @@ class DynamicsBackend(BackendV2):
             channel_carrier_freqs=channel_freqs,
             dt=dt,
             rotating_frame=rotating_frame,
-            evaluation_mode=evaluation_mode,
+            array_library=array_library,
+            vectorized=vectorized,
             rwa_cutoff_freq=rwa_cutoff_freq,
         )
 

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -736,7 +736,7 @@ def initial_state_converter(obj: Any) -> Tuple[ArrayLike, Type, Callable]:
             np.array(x), input_dims=obj.input_dims(), output_dims=obj.output_dims()
         )
     elif isinstance(obj, (BaseOperator, Gate, QuantumCircuit)):
-        y0, y0_cls = Operator(obj.data), Operator
+        y0, y0_cls = obj.data, Operator
         wrapper = lambda x: Operator(
             np.array(x), input_dims=obj.input_dims(), output_dims=obj.output_dims()
         )

--- a/test/dynamics/backend/test_backend_utils.py
+++ b/test/dynamics/backend/test_backend_utils.py
@@ -31,7 +31,7 @@ from qiskit_dynamics.backend.backend_utils import (
     _get_subsystem_probabilities,
     _get_iq_data,
 )
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import QiskitDynamicsTestCase, JAXTestBase
 
 
 class TestDressedStateDecomposition(QiskitDynamicsTestCase):
@@ -167,7 +167,7 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
         self.assertAllClose(output, np.zeros((2, 2)))
 
 
-class TestLabFrameStaticHamiltonianJAX(TestLabFrameStaticHamiltonian, TestJaxBase):
+class TestLabFrameStaticHamiltonianJAX(TestLabFrameStaticHamiltonian, JAXTestBase):
     """Tests _get_lab_frame_static_hamiltonian when in JAX mode."""
 
 

--- a/test/dynamics/backend/test_backend_utils.py
+++ b/test/dynamics/backend/test_backend_utils.py
@@ -136,7 +136,7 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
             hamiltonian_operators=[self.X],
             rotating_frame=self.X,
             array_library=array_library,
-            vectorized=vectorized
+            vectorized=vectorized,
         )
 
         output = _get_lab_frame_static_hamiltonian(model)
@@ -152,7 +152,7 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
             hamiltonian_operators=[self.X],
             rotating_frame=np.diag(self.Z),
             array_library=array_library,
-            vectorized=vectorized
+            vectorized=vectorized,
         )
 
         output = _get_lab_frame_static_hamiltonian(model)

--- a/test/dynamics/backend/test_backend_utils.py
+++ b/test/dynamics/backend/test_backend_utils.py
@@ -78,41 +78,41 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
         self.X = np.array([[0.0, 1.0], [1.0, 0.0]])
 
     @unpack
-    @data(("dense",), ("sparse",))
-    def test_HamiltonianModel(self, evaluation_mode):
+    @data(("numpy",), ("scipy_sparse",))
+    def test_HamiltonianModel(self, array_library):
         """Test correct functioning on HamiltonianModel."""
         model = HamiltonianModel(
             static_operator=self.Z + self.X,
             operators=[self.X],
             rotating_frame=self.X,
-            evaluation_mode=evaluation_mode,
+            array_library=array_library,
         )
 
         output = _get_lab_frame_static_hamiltonian(model)
         self.assertAllClose(output, self.Z + self.X)
 
     @unpack
-    @data(("dense",), ("sparse",))
-    def test_HamiltonianModel_diagonal(self, evaluation_mode):
+    @data(("numpy",), ("scipy_sparse",))
+    def test_HamiltonianModel_diagonal(self, array_library):
         """Test correct functioning on HamiltonianModel with explicitly diagonal frame."""
         model = HamiltonianModel(
             static_operator=self.Z + self.X,
             operators=[self.X],
             rotating_frame=np.diag(self.Z),
-            evaluation_mode=evaluation_mode,
+            array_library=array_library,
         )
 
         output = _get_lab_frame_static_hamiltonian(model)
         self.assertAllClose(output, self.Z + self.X)
 
     @unpack
-    @data(("dense",), ("sparse",))
-    def test_HamiltonianModel_lab_frame(self, evaluation_mode):
+    @data(("numpy",), ("scipy_sparse",))
+    def test_HamiltonianModel_lab_frame(self, array_library):
         """Test correct functioning on HamiltonianModel if no rotating frame."""
         model = HamiltonianModel(
             static_operator=self.Z + self.X,
             operators=[self.X],
-            evaluation_mode=evaluation_mode,
+            array_library=array_library,
         )
 
         output = _get_lab_frame_static_hamiltonian(model)
@@ -127,30 +127,32 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
         self.assertAllClose(output, np.zeros((2, 2)))
 
     @unpack
-    @data(("dense",), ("sparse",), ("dense_vectorized",), ("sparse_vectorized",))
-    def test_LindbladModel(self, evaluation_mode):
+    @data(("numpy", False), ("scipy_sparse", False), ("numpy", True), ("scipy_sparse", True))
+    def test_LindbladModel(self, array_library, vectorized):
         """Test correct functioning on LindbladModel."""
 
         model = LindbladModel(
             static_hamiltonian=self.Z + self.X,
             hamiltonian_operators=[self.X],
             rotating_frame=self.X,
-            evaluation_mode=evaluation_mode,
+            array_library=array_library,
+            vectorized=vectorized
         )
 
         output = _get_lab_frame_static_hamiltonian(model)
         self.assertAllClose(output, self.Z + self.X)
 
     @unpack
-    @data(("dense",), ("sparse",), ("dense_vectorized",), ("sparse_vectorized",))
-    def test_LindbladModel_diagonal(self, evaluation_mode):
+    @data(("numpy", False), ("scipy_sparse", False), ("numpy", True), ("scipy_sparse", True))
+    def test_LindbladModel_diagonal(self, array_library, vectorized):
         """Test correct functioning on LindbladModel with explicitly diagonal frame."""
 
         model = LindbladModel(
             static_hamiltonian=self.Z + self.X,
             hamiltonian_operators=[self.X],
             rotating_frame=np.diag(self.Z),
-            evaluation_mode=evaluation_mode,
+            array_library=array_library,
+            vectorized=vectorized
         )
 
         output = _get_lab_frame_static_hamiltonian(model)

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -32,7 +32,6 @@ from qiskit.providers.models.backendconfiguration import UchannelLO
 from qiskit.providers.backend import QubitProperties
 
 from qiskit_dynamics import Solver, DynamicsBackend
-from qiskit_dynamics.array import Array
 from qiskit_dynamics.backend import default_experiment_result_function
 from qiskit_dynamics.backend.dynamics_backend import (
     _get_acquire_instruction_timings,
@@ -808,7 +807,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
             },
         )
 
-        self.assertTrue(isinstance(solver.model.static_operator, Array))
+        self.assertTrue(isinstance(solver.model.static_operator, np.ndarray))
 
         N0 = np.diag(np.kron([1.0, 1.0, 1.0], [0.0, 1.0, 2.0]))
         N1 = np.diag(np.kron([0.0, 1.0, 2.0], [1.0, 1.0, 1.0]))
@@ -861,7 +860,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         """Test construction from_backend in sparse mode."""
 
         backend = DynamicsBackend.from_backend(
-            self.valid_backend, subsystem_list=[0, 1], evaluation_mode="sparse"
+            self.valid_backend, subsystem_list=[0, 1], array_library="scipy_sparse"
         )
 
         self.assertTrue(backend.target.dt == 2e-9 / 9)
@@ -931,7 +930,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
             },
         )
 
-        self.assertTrue(isinstance(solver.model.static_operator, Array))
+        self.assertTrue(isinstance(solver.model.static_operator, np.ndarray))
 
         N0 = np.diag(np.kron([1.0, 1.0, 1.0], [0.0, 1.0, 2.0]))
         N4 = np.diag(np.kron([0.0, 1.0, 2.0], [1.0, 1.0, 1.0]))

--- a/test/dynamics/backend/test_qiskit_experiments.py
+++ b/test/dynamics/backend/test_qiskit_experiments.py
@@ -45,6 +45,7 @@ class TestExperimentsIntegration(JAXTestBase):
             hamiltonian_channels=["d0"],
             channel_carrier_freqs={"d0": 5.0},
             dt=1.0 / 4.5,
+            array_library="jax",
         )
 
         # build target gate definitions

--- a/test/dynamics/backend/test_qiskit_experiments.py
+++ b/test/dynamics/backend/test_qiskit_experiments.py
@@ -26,10 +26,10 @@ from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.library.calibration.rough_frequency import RoughFrequencyCal
 
 from qiskit_dynamics import Solver, DynamicsBackend
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import JAXTestBase
 
 
-class TestExperimentsIntegration(QiskitDynamicsTestCase, TestJaxBase):
+class TestExperimentsIntegration(JAXTestBase):
     """Test class for verifying correct integration with qiskit-experiments. Set to use JAX for
     speed.
     """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This one is very simple - the backend module doesn't really use `Array` in any meaningful way.

### Details and comments

Current testing command
```
python -m unittest discover test.dynamics.backend; python -m unittest discover test.dynamics.perturbation; python -m unittest discover test.dynamics.models; python -m unittest discover test.dynamics.arraylias; python -m unittest discover test.dynamics.signals; python -m unittest discover test.dynamics.pulse; python -m unittest discover test.dynamics.solvers;
```