### PR TITLE
Relax pin on Qiskit 1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,35 @@ jobs:
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os == 'Windows'
+  test-qiskit-1:
+    name: tests-python3.10-ubuntu-latest-qiskit-1.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+            ${{ runner.os }}-${{ matrix.python-version }}
+      - name: Install package
+        run: |
+          set -e
+          python -m pip install -U pip
+          python -m pip install \
+            -c constraints.txt \
+            -r requirements-dev.txt \
+            jax jaxlib diffrax \
+            'qiskit>=1.0.0rc1' \
+            .
+      - name: Run tests
+        run: stestr run
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy>=1.17",
     "scipy>=1.4",
     "matplotlib>=3.0",
-    "qiskit<1.0",
+    "qiskit",
     "multiset>=3.0.1",
     "sympy>=1.12",
     "arraylias"

--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -17,11 +17,16 @@ from ddt import ddt, data, unpack
 import numpy as np
 import sympy as sym
 
+import qiskit
 from qiskit import pulse
 from qiskit.pulse import Schedule
 from qiskit.pulse.transforms.canonicalization import block_to_schedule
-from qiskit.providers.fake_provider import FakeQuito
 from qiskit import QiskitError
+
+if qiskit.__version__.startswith("0."):
+    from qiskit.providers.fake_provider import FakeNairobi as Fake7QPulseV1
+else:
+    from qiskit.providers.fake_provider import Fake7QPulseV1
 
 from qiskit_dynamics.pulse import InstructionToSignals
 from qiskit_dynamics.signals import DiscreteSignal
@@ -338,7 +343,7 @@ class TestPulseToSignals(QiskitDynamicsTestCase):
         """Test correct parsing of schedule with barrier instructions."""
 
         # this example needs any backend with at least 2 qubits
-        backend = FakeQuito()
+        backend = Fake7QPulseV1()
 
         with pulse.build(backend) as sched_block:
             pulse.play(pulse.Constant(duration=3, amp=0.5), pulse.DriveChannel(0))


### PR DESCRIPTION
### Summary

This particular pulse test appears to be the only thing that changes in Qiskit 1.0.  This commit adds a CI job to test against Qiskit 1.0.0rc1 (which can be removed, or made to target `qiskit<1` after 1.0.0 final is released), and relaxes the pin on `qiskit`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

The new test run will explode right now because of incompatible dependencies, but locally I used a modified version of `qiskit-experiments` that stubbed out the bits that don't work with Qiskit 1.0, and this passed the test suite for me.

This is presumably on hold til `qiskit-experiments` is ready.

Admittedly I was running without Jax or diffrax - I assume that's not going to change anything, but I guess we'll see.