### PR TITLE
Remove Array class from pulse_to_signals

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install Deps
         run: pip install -U wheel
       - name: Build Artifacts

--- a/docs/tutorials/optimizing_pulse_sequence.rst
+++ b/docs/tutorials/optimizing_pulse_sequence.rst
@@ -319,6 +319,8 @@ entry on :ref:`JAX-compatible pulse schedules <how-to use pulse schedules for ja
             )
         )
 
+        pulse.ScalableSymbolicPulse.disable_validation = True
+
         return pulse.ScalableSymbolicPulse(
                 pulse_type="GaussianSquare",
                 duration=230,

--- a/docs/tutorials/optimizing_pulse_sequence.rst
+++ b/docs/tutorials/optimizing_pulse_sequence.rst
@@ -319,6 +319,7 @@ entry on :ref:`JAX-compatible pulse schedules <how-to use pulse schedules for ja
             )
         )
 
+        # we need to set disable_validation True to enable jax-jitting.
         pulse.ScalableSymbolicPulse.disable_validation = True
 
         return pulse.ScalableSymbolicPulse(

--- a/docs/userguide/how_to_use_pulse_schedule_for_jax_jit.rst
+++ b/docs/userguide/how_to_use_pulse_schedule_for_jax_jit.rst
@@ -121,6 +121,8 @@ JAX-compiled (or more generally, JAX-transformed).
             _amp * sym.exp(sym.I * _angle) * lifted_gaussian(_t, _center, _duration + 1, _sigma)
         )
 
+        pulse.ScalableSymbolicPulse.disable_validation = True
+
         gaussian_pulse = pulse.ScalableSymbolicPulse(
                 pulse_type="Gaussian",
                 duration=160,

--- a/docs/userguide/how_to_use_pulse_schedule_for_jax_jit.rst
+++ b/docs/userguide/how_to_use_pulse_schedule_for_jax_jit.rst
@@ -121,6 +121,7 @@ JAX-compiled (or more generally, JAX-transformed).
             _amp * sym.exp(sym.I * _angle) * lifted_gaussian(_t, _center, _duration + 1, _sigma)
         )
 
+        # we need to set disable_validation True to enable jax-jitting.
         pulse.ScalableSymbolicPulse.disable_validation = True
 
         gaussian_pulse = pulse.ScalableSymbolicPulse(

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -360,7 +360,10 @@ def get_samples(pulse: SymbolicPulse) -> ArrayLike:
                 f"Pulse parameter '{symbol.name}' is not defined for this instance. "
                 "Please check your waveform expression is correct."
             ) from ex
-    return _lru_cache_expr(envelope, "jax" if any(isinstance(v, jax.core.Tracer) for v in pulse_params.values()) else "numpy")(*args)
+    return _lru_cache_expr(
+        envelope,
+        "jax" if any(isinstance(v, jax.core.Tracer) for v in pulse_params.values()) else "numpy",
+    )(*args)
 
 
 @functools.lru_cache(maxsize=None)

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -348,6 +348,12 @@ def get_samples(pulse: SymbolicPulse) -> ArrayLike:
         raise PulseError("Pulse envelope expression is not assigned.")
 
     args = []
+    try:
+        backend = (
+            "jax" if any(isinstance(v, jax.core.Tracer) for v in pulse_params.values()) else "numpy"
+        )
+    except (ImportError, NameError):
+        backend = "numpy"
     for symbol in sorted(envelope.free_symbols, key=lambda s: s.name):
         if symbol.name == "t":
             times = unp.arange(0, pulse_params["duration"]) + 1 / 2
@@ -362,7 +368,7 @@ def get_samples(pulse: SymbolicPulse) -> ArrayLike:
             ) from ex
     return _lru_cache_expr(
         envelope,
-        "jax" if any(isinstance(v, jax.core.Tracer) for v in pulse_params.values()) else "numpy",
+        backend,
     )(*args)
 
 

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -39,7 +39,6 @@ from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.library import SymbolicPulse
 from qiskit import QiskitError
 
-from qiskit_dynamics.array import Array
 from qiskit_dynamics import DYNAMICS_NUMPY as unp
 from qiskit_dynamics import ArrayLike
 
@@ -361,7 +360,7 @@ def get_samples(pulse: SymbolicPulse) -> ArrayLike:
                 f"Pulse parameter '{symbol.name}' is not defined for this instance. "
                 "Please check your waveform expression is correct."
             ) from ex
-    return _lru_cache_expr(envelope, Array.default_backend())(*args)
+    return _lru_cache_expr(envelope, "jax" if any(isinstance(v, jax.core.Tracer) for v in pulse_params.values()) else "numpy")(*args)
 
 
 @functools.lru_cache(maxsize=None)

--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -371,6 +371,9 @@ class TestPulseToSignalsJAXTransformations(JAXTestBase):
         self.constant_get_waveform_samples = (
             pulse.Constant(duration=5, amp=0.1).get_waveform().samples
         )
+        self.gaussian_get_waveform_samples = (
+            pulse.Gaussian(duration=5, amp=0.983, sigma=2.0).get_waveform().samples
+        )
         self._dt = 0.222
 
     def test_InstructionToSignals_with_JAX(self):
@@ -414,7 +417,7 @@ class TestPulseToSignalsJAXTransformations(JAXTestBase):
 
         jit(jit_func_gaussian_to_signals)(0.983)
         self.jit_grad(jit_func_gaussian_to_signals)(0.983)
-        jit_samples = jit(jit_func_gaussian_to_signals)(0.983)
+        jit_gaussian_samples = jit(jit_func_gaussian_to_signals)(0.983)
         self.assertAllClose(
             jit_gaussian_samples, self.gaussian_get_waveform_samples, atol=1e-7, rtol=1e-7
         )

--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -432,6 +432,8 @@ class TestPulseToSignalsJAXTransformations(JAXTestBase):
                 (1, sym.And(_time >= 0, _time <= _duration)), (0, True)
             )
             valid_amp_conditions_expr = sym.Abs(_amp) <= 1.0
+            # we need to set disable_validation True to enable jax-jitting.
+            pulse.SymbolicPulse.disable_validation = True
             instance = pulse.SymbolicPulse(
                 pulse_type="Constant",
                 duration=5,

--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -25,10 +25,15 @@ from qiskit import QiskitError
 
 from qiskit_ibm_runtime.fake_provider import FakeQuito
 
+try:
+    from jax import jit
+except ImportError:
+    pass
+
 from qiskit_dynamics.pulse import InstructionToSignals
 from qiskit_dynamics.signals import DiscreteSignal
 
-from ..common import QiskitDynamicsTestCase, TestJaxBase
+from ..common import QiskitDynamicsTestCase, JAXTestBase
 
 
 class TestPulseToSignals(QiskitDynamicsTestCase):
@@ -358,7 +363,7 @@ class TestPulseToSignals(QiskitDynamicsTestCase):
         self.assertAllClose(sigs[1].samples, np.array([0.0, 0.0, 0.0, -0.5, -0.5, -0.5]))
 
 
-class TestPulseToSignalsJAXTransformations(QiskitDynamicsTestCase, TestJaxBase):
+class TestPulseToSignalsJAXTransformations(JAXTestBase):
     """Tests InstructionToSignals class by using Jax."""
 
     def setUp(self):
@@ -393,9 +398,9 @@ class TestPulseToSignalsJAXTransformations(QiskitDynamicsTestCase, TestJaxBase):
             converter = InstructionToSignals(self._dt, carriers={"d0": 5})
             return converter.get_signals(schedule)[0].samples
 
-        self.jit_wrap(jit_func_instruction_to_signals)(0.1)
-        self.jit_grad_wrap(jit_func_instruction_to_signals)(0.1)
-        jit_samples = self.jit_wrap(jit_func_instruction_to_signals)(0.1)
+        jit(jit_func_instruction_to_signals)(0.1)
+        self.jit_grad(jit_func_instruction_to_signals)(0.1)
+        jit_samples = jit(jit_func_instruction_to_signals)(0.1)
         self.assertAllClose(jit_samples, self.constant_get_waveform_samples, atol=1e-7, rtol=1e-7)
 
     def test_pulse_types_combination_with_jax(self):
@@ -430,8 +435,8 @@ class TestPulseToSignalsJAXTransformations(QiskitDynamicsTestCase, TestJaxBase):
             converter = InstructionToSignals(self._dt, carriers={"d0": 5})
             return converter.get_signals(schedule)[0].samples
 
-        self.jit_wrap(jit_func_symbolic_pulse)(0.1)
-        self.jit_grad_wrap(jit_func_symbolic_pulse)(0.1)
+        jit(jit_func_symbolic_pulse)(0.1)
+        self.jit_grad(jit_func_symbolic_pulse)(0.1)
 
 
 @ddt

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -1360,6 +1360,8 @@ class TestPulseSimulationJAXPeculiarities:
                 (1, sym.And(_time >= 0, _time <= _duration)), (0, True)
             )
             valid_amp_conditions_expr = sym.Abs(_amp) <= 1.0
+            # we need to set disable_validation True to enable jax-jitting.
+            pulse.SymbolicPulse.disable_validation = True
             return pulse.SymbolicPulse(
                 pulse_type="Constant",
                 duration=5,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Removed Array class.
It checks whether the pulse parameters type is Jax.core.Tracer.


### Details and comments
Related to #326.

