### PR TITLE
Update models API docs

### DIFF
--- a/docs/userguide/how_to_configure_simulations.rst
+++ b/docs/userguide/how_to_configure_simulations.rst
@@ -204,7 +204,7 @@ with extra emphasis on the following:
 .. note::
 
     As stated in the
-    :ref:`evaluation modes section of the Models API documentation <evaluation modes>`,
+    :ref:`model evaluation section of the Models API documentation <model evaluation>`,
     when using a sparse evaluation mode, to preserve sparsity, it is recommended to
     only use *diagonal* rotating frames, which can be specified as a 1d array to the
     ``rotating_frame`` kwarg of :class:`.Solver` instantiation.

--- a/qiskit_dynamics/models/__init__.py
+++ b/qiskit_dynamics/models/__init__.py
@@ -90,7 +90,7 @@ time-dependent components, above a given cutoff frequency, are removed from a mo
 transformation is implemented in :meth:`~qiskit_dynamics.models.rotating_wave_approximation`, see
 its documentation for details.
 
-.. _evaluation modes:
+.. _model evaluation:
 
 Controlling model evaluation: array libraries and vectorization
 ===============================================================

--- a/qiskit_dynamics/models/__init__.py
+++ b/qiskit_dynamics/models/__init__.py
@@ -92,19 +92,18 @@ its documentation for details.
 
 .. _evaluation modes:
 
-Numerical methods and evaluation modes
-======================================
+Controlling model evaluation: array libraries and vectorization
+===============================================================
 
-All model classes offer different underlying numerical implementations that a user can choose using
-the ``evaluation_mode`` property. For example, :class:`~qiskit_dynamics.models.HamiltonianModel` can
-internally use either sparse or dense arrays to compute :math:`H(t)` or a product :math:`-iH(t)y`.
-The default is dense arrays, and a model can be set to use sparse arrays via:
+The underlying array library used by any model class can be controlled via the ``array_library``
+instantiation argument. The model will store the underlying arrays using the specified library, and
+use this library to evaluate the model. See the :mod:`.arraylias` submodule API documentation for a
+list of ``array_library`` options. If unspecified, the model will use the general dispatching rules
+of the configured aliases in :mod:`.arraylias` to determine which library to use based on how the
+operators are specified.
 
-.. code-block:: python
-
-    model.evaluation_mode = "sparse"
-
-See the ``evaluation_mode`` property for each model class for available modes.
+Additionally, the :class:`.LindbladModel` class can be set to store and evaluate the Lindblad
+equation in a matrix-vector vectorized format using the ``vectorized`` instatiation argument.
 
 .. note::
 

--- a/qiskit_dynamics/models/generator_model.py
+++ b/qiskit_dynamics/models/generator_model.py
@@ -91,7 +91,7 @@ class BaseGeneratorModel(ABC):
             y: Optional state.
 
         Returns:
-            Array: Either the evaluated model, or the RHS for the given y.
+            ArrayLike: Either the evaluated model, or the RHS for the given y.
         """
         return self.evaluate(time) if y is None else self.evaluate_rhs(time, y)
 
@@ -254,7 +254,7 @@ class GeneratorModel(BaseGeneratorModel):
             time: The time to evaluate the model at.
 
         Returns:
-            Array: The evaluated model as a matrix.
+            ArrayLike: The evaluated model as a matrix.
 
         Raises:
             QiskitError: If model cannot be evaluated.

--- a/qiskit_dynamics/models/generator_model.py
+++ b/qiskit_dynamics/models/generator_model.py
@@ -45,6 +45,10 @@ class BaseGeneratorModel(ABC):
     map :math:`\Lambda(t, \cdot)`.
     """
 
+    def __init__(self, array_library: Optional[str] = None):
+        """Set up general information used by all subclasses."""
+        self._array_library = array_library
+
     @property
     @abstractmethod
     def dim(self) -> int:
@@ -61,9 +65,9 @@ class BaseGeneratorModel(ABC):
         """Whether or not the model is evaluated in the basis in which the frame is diagonalized."""
 
     @property
-    @abstractmethod
     def array_library(self) -> Union[None, str]:
         """Array library used to store the operators in the model."""
+        return self._array_library
 
     @abstractmethod
     def evaluate(self, time: float) -> ArrayLike:
@@ -144,7 +148,6 @@ class GeneratorModel(BaseGeneratorModel):
                 "be specified at construction."
             )
 
-        self._array_library = array_library
         self._rotating_frame = RotatingFrame(rotating_frame)
         self._in_frame_basis = in_frame_basis
 
@@ -166,6 +169,8 @@ class GeneratorModel(BaseGeneratorModel):
         self._signals = None
         self.signals = signals
 
+        super().__init__(array_library=array_library)
+
     @property
     def dim(self) -> int:
         """The matrix dimension."""
@@ -184,11 +189,6 @@ class GeneratorModel(BaseGeneratorModel):
     @in_frame_basis.setter
     def in_frame_basis(self, in_frame_basis: bool):
         self._in_frame_basis = in_frame_basis
-
-    @property
-    def array_library(self) -> Union[None, str]:
-        """Array library used to store the operators in the model."""
-        return self._array_library
 
     @property
     def static_operator(self) -> Union[ArrayLike, None]:

--- a/qiskit_dynamics/models/generator_model.py
+++ b/qiskit_dynamics/models/generator_model.py
@@ -66,7 +66,12 @@ class BaseGeneratorModel(ABC):
 
     @property
     def array_library(self) -> Union[None, str]:
-        """Array library used to store the operators in the model."""
+        """Array library with which to represent the operators in the model, and to evaluate the
+        model.
+        
+        See the list of supported array libraries in the :mod:`.arraylias` submodule API
+        documentation.
+        """
         return self._array_library
 
     @abstractmethod
@@ -136,9 +141,10 @@ class GeneratorModel(BaseGeneratorModel):
             rotating_frame: Rotating frame operator.
             in_frame_basis: Whether to represent the model in the basis in which the rotating frame
                 operator is diagonalized.
-            array_library: Array library for storing the operators in the model. Supported options
-                are ``'numpy'``, ``'jax'``, ``'jax_sparse'``, and ``'scipy_sparse'``. If ``None``,
-                the arrays will be handled by general dispatching rules.
+            array_library: Array library with which to represent the operators in the model, and to 
+                evaluate the model. See the list of supported array libraries in the 
+                :mod:`.arraylias` submodule API documentation. If ``None``, the arrays will be
+                handled by general dispatching rules.
         Raises:
             QiskitError: If model not sufficiently specified.
         """

--- a/qiskit_dynamics/models/generator_model.py
+++ b/qiskit_dynamics/models/generator_model.py
@@ -68,7 +68,7 @@ class BaseGeneratorModel(ABC):
     def array_library(self) -> Union[None, str]:
         """Array library with which to represent the operators in the model, and to evaluate the
         model.
-        
+
         See the list of supported array libraries in the :mod:`.arraylias` submodule API
         documentation.
         """
@@ -141,8 +141,8 @@ class GeneratorModel(BaseGeneratorModel):
             rotating_frame: Rotating frame operator.
             in_frame_basis: Whether to represent the model in the basis in which the rotating frame
                 operator is diagonalized.
-            array_library: Array library with which to represent the operators in the model, and to 
-                evaluate the model. See the list of supported array libraries in the 
+            array_library: Array library with which to represent the operators in the model, and to
+                evaluate the model. See the list of supported array libraries in the
                 :mod:`.arraylias` submodule API documentation. If ``None``, the arrays will be
                 handled by general dispatching rules.
         Raises:

--- a/qiskit_dynamics/models/hamiltonian_model.py
+++ b/qiskit_dynamics/models/hamiltonian_model.py
@@ -82,8 +82,8 @@ class HamiltonianModel(GeneratorModel):
                 F = -iH.
             in_frame_basis: Whether to represent the model in the basis in which the rotating
                 frame operator is diagonalized.
-            array_library: Array library with which to represent the operators in the model, and to 
-                evaluate the model. See the list of supported array libraries in the 
+            array_library: Array library with which to represent the operators in the model, and to
+                evaluate the model. See the list of supported array libraries in the
                 :mod:`.arraylias` submodule API documentation. If ``None``, the arrays will be
                 handled by general dispatching rules.
             validate: If ``True`` check input operators are Hermitian. Note that this is

--- a/qiskit_dynamics/models/hamiltonian_model.py
+++ b/qiskit_dynamics/models/hamiltonian_model.py
@@ -82,10 +82,10 @@ class HamiltonianModel(GeneratorModel):
                 F = -iH.
             in_frame_basis: Whether to represent the model in the basis in which the rotating
                 frame operator is diagonalized.
-            array_library: Array library for storing the operators in the model. Supported options
-                are ``'numpy'``, ``'jax'``, ``'jax_sparse'``, and ``'scipy_sparse'``. If ``None``,
-                the arrays will be handled by general dispatching rules. Call
-                ``help(GeneratorModel.array_library)`` for more details.
+            array_library: Array library with which to represent the operators in the model, and to 
+                evaluate the model. See the list of supported array libraries in the 
+                :mod:`.arraylias` submodule API documentation. If ``None``, the arrays will be
+                handled by general dispatching rules.
             validate: If ``True`` check input operators are Hermitian. Note that this is
                 incompatible with JAX transformations.
 

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -125,8 +125,8 @@ class LindbladModel(BaseGeneratorModel):
                 assumed that all operators were already in the frame basis.
             in_frame_basis: Whether to represent the model in the basis in which the rotating
                 frame operator is diagonalized.
-            array_library: Array library with which to represent the operators in the model, and to 
-                evaluate the model. See the list of supported array libraries in the 
+            array_library: Array library with which to represent the operators in the model, and to
+                evaluate the model. See the list of supported array libraries in the
                 :mod:`.arraylias` submodule API documentation. If ``None``, the arrays will be
                 handled by general dispatching rules.
             vectorized: Whether or not to setup the Lindblad equation in vectorized mode.

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -417,7 +417,7 @@ class LindbladModel(BaseGeneratorModel):
             time: The time at which to evaluate the Hamiltonian.
 
         Returns:
-            Array: Hamiltonian matrix.
+            ArrayLike: Hamiltonian matrix.
         """
 
         hamiltonian_sig_vals = None
@@ -443,7 +443,7 @@ class LindbladModel(BaseGeneratorModel):
             time: The time to evaluate the model at.
 
         Returns:
-            Array: The evaluated model as an anti-Hermitian matrix.
+            ArrayLike: The evaluated model as an anti-Hermitian matrix.
 
         Raises:
             QiskitError: If model cannot be evaluated.
@@ -482,11 +482,11 @@ class LindbladModel(BaseGeneratorModel):
 
         Args:
             time: The time at which the model should be evaluated.
-            y: Density matrix as an (n,n) Array if not using a vectorized evaluation_mode, or an
-               (n^2) Array if using vectorized evaluation.
+            y: Density matrix as an (n,n) Array if not vectorized, or an (n^2) Array if using
+                vectorized evaluation.
 
         Returns:
-            Array: Either the evaluated generator or the state.
+            ArrayLike: Either the evaluated generator or the state.
 
         Raises:
             QiskitError: If signals not sufficiently specified.

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -159,7 +159,6 @@ class LindbladModel(BaseGeneratorModel):
             ):
                 raise QiskitError("""LindbladModel hamiltonian_operators must be Hermitian.""")
 
-        self._array_library = array_library
         self._vectorized = vectorized
         self._rotating_frame = RotatingFrame(rotating_frame)
         self._in_frame_basis = in_frame_basis
@@ -208,6 +207,8 @@ class LindbladModel(BaseGeneratorModel):
         )
 
         self.signals = (hamiltonian_signals, dissipator_signals)
+
+        super().__init__(array_library=array_library)
 
     @classmethod
     def from_hamiltonian(
@@ -394,11 +395,6 @@ class LindbladModel(BaseGeneratorModel):
         return self.rotating_frame.operator_out_of_frame_basis(
             self._operator_collection.dissipator_operators
         )
-
-    @property
-    def array_library(self) -> Union[None, str]:
-        """Array library used to store the operators in the model."""
-        return self._array_library
 
     @property
     def vectorized(self) -> bool:

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -125,9 +125,10 @@ class LindbladModel(BaseGeneratorModel):
                 assumed that all operators were already in the frame basis.
             in_frame_basis: Whether to represent the model in the basis in which the rotating
                 frame operator is diagonalized.
-            array_library: Array library for storing the operators in the model. Supported options
-                are ``'numpy'``, ``'jax'``, ``'jax_sparse'``, and ``'scipy_sparse'``. If ``None``,
-                the arrays will be handled by general dispatching rules.
+            array_library: Array library with which to represent the operators in the model, and to 
+                evaluate the model. See the list of supported array libraries in the 
+                :mod:`.arraylias` submodule API documentation. If ``None``, the arrays will be
+                handled by general dispatching rules.
             vectorized: Whether or not to setup the Lindblad equation in vectorized mode.
                 If ``True``, the operators in the model are stored as :math:`(dim^2,dim^2)` matrices
                 that act on vectorized density matrices by left-multiplication. Setting this to

--- a/qiskit_dynamics/models/model_utils.py
+++ b/qiskit_dynamics/models/model_utils.py
@@ -50,7 +50,7 @@ def vec_commutator(
            list of sparse matrices.
 
     Returns:
-        Array: vectorized version of the map.
+        ArrayLike: Vectorized version of the map.
     """
 
     if issparse(A):

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -201,7 +201,7 @@ class ScipySparseOperatorCollection:
             coefficients: The coefficient values :math:`c` to use on the operators.
 
         Returns:
-            An :class:`~Array` that acts on states ``y`` via multiplication.
+            A scipy sparse matrix that acts on states ``y`` via multiplication.
 
         Raises:
             QiskitError: If collection cannot be evaluated.

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -852,18 +852,7 @@ class VectorizedLindbladCollection:
     """Vectorized Lindblad collection class.
 
     The vectorized Lindblad equation represents the Lindblad master equation in the structure
-    of a linear matrix differential equation in standard form. Hence, this class inherits
-    from both ``BaseLindbladOperatorCollection`` and ``BaseOperatorCollection``.
-
-    This class manages the general property handling of converting operators in a Lindblad
-    collection to the correct type, constructing vectorized versions, and combining for use in a
-    BaseOperatorCollection. Requires implementation of:
-
-        - ``convert_to_internal_type``: Convert operators to the required internal type,
-          e.g. csr or Array.
-        - ``evaluation_class``: Class property that returns the subclass of BaseOperatorCollection
-          to be used when evaluating the model, e.g. DenseOperatorCollection or
-          SparseOperatorCollection.
+    of a linear matrix differential equation in standard form.
 
     This class works for ``array_library in ["numpy", "jax", "jax_sparse"]``.
     """

--- a/qiskit_dynamics/models/rotating_frame.py
+++ b/qiskit_dynamics/models/rotating_frame.py
@@ -158,7 +158,7 @@ class RotatingFrame:
             y: The state.
 
         Returns:
-            Array: The state in the frame basis.
+            ArrayLike: The state in the frame basis.
         """
         y = unp.asarray(y)
         if self.frame_basis is None:
@@ -181,7 +181,7 @@ class RotatingFrame:
                           ``op`` is a handled input type.
 
         Returns:
-            Array: The operator in the frame basis.
+            ArrayLike: The operator in the frame basis.
         """
         if convert_type:
             op = unp.asarray(op)

--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -75,18 +75,19 @@ def rotating_wave_approximation(
 
         .. code-block:: python
 
-            rwa_model, signal_map = rotating_wave_approximation(model,
-                                                                cutoff_freq,
-                                                                return_signal_map=True)
+            rwa_model, signal_map = rotating_wave_approximation(
+                model,
+                cutoff_freq,
+                return_signal_map=True
+            )
 
         The following function **is** JAX-transformable:
 
         .. code-block:: python
 
             def jax_transformable_func(t):
-                rwa_model_copy = rwa_model.copy()
-                rwa_model_copy.signals = signal_map(new_signals)
-                return rwa_model_copy(t)
+                rwa_model.signals = signal_map(new_signals)
+                return rwa_model(t)
 
         In this way, the outputs of ``rotating_wave_approximation`` can be used in JAX-transformable
         functions, however ``rotating_wave_approximation`` itself cannot.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates the `models` module API docs to reflect the change of ``evaluation_mode`` to ``array_library`` and ``vectorized``.

### Details and comments

In the interest of minimizing further documentation maintenance, I also slightly changed the `BaseGeneratorModel` abstract base class to implement the `array_library` property. 
- Previously, this property was kept abstract, and was implemented by all subclasses. 
- Now, the `BaseGeneratorModel` class has an `__init__` that sets `self._array_library`, and implements a concrete `array_library` property.

This enabled deleting the `array_library` property for `GeneratorModel`, `HamiltonianModel`, and `LindbladModel`. As a result, changes to documentation of this property only need to be made in one place.
