### PR TITLE
Fix a bug where y0 of type np.ndarray throws an exception in DynamicsBackend.solve

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -380,7 +380,7 @@ class DynamicsBackend(BackendV2):
         # use default y0 if not given as parameter
         if y0 is None:
             y0 = self.options.initial_state
-        if y0 == "ground_state":
+        if isinstance(y0, str) and y0 == "ground_state":
             y0 = Statevector(self._dressed_states[:, 0])
 
         solver_results = self.options.solver.solve(

--- a/releasenotes/notes/fix-dynamics-backend-solve-bug-9feec2f51f62f9d3.yaml
+++ b/releasenotes/notes/fix-dynamics-backend-solve-bug-9feec2f51f62f9d3.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    :meth:`.DynamicsBackend.solve` method has been fixed to allow `y0` values of type `np.ndarray`.

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -342,6 +342,8 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         y0_and_expected_results.append(
             (None, Statevector(QuantumCircuit(1)).evolve(expected_unitary))
         )
+        # y0 is a np.array, we expect a np.array as a result
+        y0_and_expected_results.append((np.eye(static_ham.shape[0]), expected_unitary))
         input_variety = [x_sched0, x_circ0]
 
         # solve for all combinations of input types and initial states


### PR DESCRIPTION
### Summary

Using a `np.ndarray` as parameter value for `y0` in `DynamicsBackend.solve(...)` threw an exception.
This was solved by adding a check if the parameter is of type `str` before checking the equality with `==`

fixes #350 

### Details and comments

Straightforward implementation.
Added the case to the unitest for `DynamicsBackend.solve(..)`