### PR TITLE
Default t_span available for `DynamicsBackend.solve`

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -361,7 +361,8 @@ class DynamicsBackend(BackendV2):
         ``y0`` is not specified, it will be set from ``self.options.initial_state``.
 
         Args:
-            t_span: Time interval to integrate over.
+            t_span: Time interval to integrate over. Defaults to ``None``, in which case the
+                    interval is set to [[0, input.duration] for input in solve_input]].
             y0: Initial state.
             solve_input: Time evolution of the system in terms of quantum circuits or qiskit
                          pulse schedules.

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -345,7 +345,7 @@ class DynamicsBackend(BackendV2):
     def solve(
         self,
         solve_input: List[Union[QuantumCircuit, Schedule, ScheduleBlock]],
-        t_span: ArrayLike,
+        t_span: Optional[ArrayLike] = None,
         y0: Optional[Union[ArrayLike, QuantumState, BaseOperator]] = None,
         convert_results: Optional[bool] = True,
         validate: Optional[bool] = True,
@@ -382,7 +382,8 @@ class DynamicsBackend(BackendV2):
             y0 = self.options.initial_state
         if isinstance(y0, str) and y0 == "ground_state":
             y0 = Statevector(self._dressed_states[:, 0])
-
+        if t_span is None:
+            t_span = [[0, sched.duration * self.dt] for sched in schedules]
         solver_results = self.options.solver.solve(
             t_span=t_span,
             y0=y0,

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -362,7 +362,7 @@ class DynamicsBackend(BackendV2):
 
         Args:
             t_span: Time interval to integrate over. Defaults to ``None``, in which case the
-                    interval is set to [[0, input.duration] for input in solve_input]].
+                    interval is set to ``[[0, input.duration] for input in solve_input]]``.
             y0: Initial state.
             solve_input: Time evolution of the system in terms of quantum circuits or qiskit
                          pulse schedules.

--- a/releasenotes/notes/default_tspan_backend_solve-b1ad23f6ea291474.yaml
+++ b/releasenotes/notes/default_tspan_backend_solve-b1ad23f6ea291474.yaml
@@ -1,6 +1,7 @@
 ---
-features:
-  - `DynamicsBackend.solve()` method can now work without specifying a t_span argument. 
+upgrade:
+  - |
+    `DynamicsBackend.solve()` method can now work without specifying a t_span argument. 
     The default t_span is set to be [0, solve_input.duration] for each provided solve_input.
     This allows users to solve the dynamics of a quantum circuit without having to specify its
     duration in advance.

--- a/releasenotes/notes/default_tspan_backend_solve-b1ad23f6ea291474.yaml
+++ b/releasenotes/notes/default_tspan_backend_solve-b1ad23f6ea291474.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    `DynamicsBackend.solve()` method can now work without specifying a t_span argument. 
-    The default t_span is set to be [0, solve_input.duration] for each provided solve_input.
+    ``DynamicsBackend.solve()`` method can now work without specifying a ``t_span`` argument. 
+    The default ``t_span`` is set to be ``[0, solve_input.duration]`` for each provided ``solve_input``.
     This allows users to solve the dynamics of a quantum circuit without having to specify its
     duration in advance.

--- a/releasenotes/notes/default_tspan_backend_solve-b1ad23f6ea291474.yaml
+++ b/releasenotes/notes/default_tspan_backend_solve-b1ad23f6ea291474.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - `DynamicsBackend.solve()` method can now work without specifying a t_span argument. 
+    The default t_span is set to be [0, solve_input.duration] for each provided solve_input.
+    This allows users to solve the dynamics of a quantum circuit without having to specify its
+    duration in advance.

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -347,9 +347,11 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         input_variety = [x_sched0, x_circ0]
 
         # solve for all combinations of input types and initial states
-        for solve_input, (y0, expected_result) in product(input_variety, y0_and_expected_results):
+        for solve_input, (y0, expected_result), t_span in product(
+            input_variety, y0_and_expected_results, ([0, n_samples * backend.dt], None)
+        ):
             solver_results = backend.solve(
-                t_span=[0, n_samples * backend.dt],
+                t_span=t_span,
                 y0=y0,
                 solve_input=[solve_input],
             )
@@ -358,6 +360,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             for solver_result in solver_results:
                 self.assertTrue(solver_result.success)
                 self.assertAllClose(solver_result.y[-1], expected_result, atol=1e-8, rtol=1e-8)
+                self.assertEqual(solver_result.t[-1], n_samples * backend.dt)
 
     def test_pi_pulse_initial_state(self):
         """Test simulation of a pi pulse with a different initial state."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR introduces the possibility to use `DynamicsBackend.solve()`without having to specify a `t_span`argument explicitly. If it is not specified, the default `t_span`is inferred from the provided `solve_input` to create a `t_span`of the form [0, solve_input.duration] for each solve_input in the provided list. This can be useful for simulating easily a full `QuantumCircuit`s as the process of converting them to `Schedule` is already done behind the scenes. 


### Details and comments


