### PR TITLE
Fix qutip Qobj handling for qutip 5.0.0

### DIFF
--- a/qiskit_dynamics/arraylias/register_functions/asarray.py
+++ b/qiskit_dynamics/arraylias/register_functions/asarray.py
@@ -29,13 +29,7 @@ def _isinstance_qutip_qobj(obj):
     Returns:
         Bool: True if obj is qutip Qobj
     """
-    if (
-        type(obj).__name__ == "Qobj"
-        and hasattr(obj, "_data")
-        and type(obj._data).__name__ == "fast_csr_matrix"
-    ):
-        return True
-    return False
+    return type(obj).__name__ == "Qobj"
 
 
 def register_asarray(alias):
@@ -44,7 +38,7 @@ def register_asarray(alias):
     @alias.register_default(path="asarray")
     def _(arr):
         if _isinstance_qutip_qobj(arr):
-            return csr_matrix(arr)
+            return arr.full()
         return np.asarray(arr)
 
     @alias.register_function(lib="scipy_sparse", path="asarray")

--- a/releasenotes/notes/qutip-qobj-handling-5ed79d8e4b5e96a7.yaml
+++ b/releasenotes/notes/qutip-qobj-handling-5ed79d8e4b5e96a7.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    To enable compatibility with QuTiP 5.0.0, ``qutip.Qobj`` instances are now converted to a raw
+    array type in Dynamics via the ``qutip.Qobj.full`` method. This method always returns a dense
+    array, and hence ``qutip.Qobj`` instances are no longer turned into ``scipy.sparse.csr_matrix``
+    instances in Dynamics. 

--- a/test/dynamics/arraylias/test_alias.py
+++ b/test/dynamics/arraylias/test_alias.py
@@ -182,6 +182,7 @@ class Test_qutip_qobj_asarray(QutipTestBase):
 
         qobj = Qobj([[0, 1], [1, 0]])
 
-        out = unp.asarray(qobj)
-        self.assertTrue(isinstance(out, csr_matrix))
-        self.assertAllClose(out.todense(), np.array([[0.0, 1.0], [1.0, 0.0]]))
+        out = unp.asarray(qobj)\
+        
+        self.assertTrue(isinstance(out, np.ndarray))
+        self.assertAllClose(out, np.array([[0.0, 1.0], [1.0, 0.0]]))

--- a/test/dynamics/arraylias/test_alias.py
+++ b/test/dynamics/arraylias/test_alias.py
@@ -182,7 +182,6 @@ class Test_qutip_qobj_asarray(QutipTestBase):
 
         qobj = Qobj([[0, 1], [1, 0]])
 
-        out = unp.asarray(qobj)\
-        
+        out = unp.asarray(qobj)
         self.assertTrue(isinstance(out, np.ndarray))
         self.assertAllClose(out, np.array([[0.0, 1.0], [1.0, 0.0]]))

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -521,16 +521,16 @@ class TestRotatingFrameTypeHandling(NumpyTestBase):
         t = 0.123
         y = qutip.Qobj([[1.0, 1]])
         out = rotating_frame.state_into_frame(t, y)
-        self.assertTrue(isinstance(out, csr_matrix))
+        self.assertTrue(isinstance(out, np.ndarray))
         out = rotating_frame.state_out_of_frame(t, y)
-        self.assertTrue(isinstance(out, csr_matrix))
+        self.assertTrue(isinstance(out, np.ndarray))
 
         t = 100.12498
-        y = csr_matrix(np.eye(2))
+        y = qutip.Qobj(np.eye(2))
         out = rotating_frame.state_into_frame(t, y)
-        self.assertTrue(isinstance(out, csr_matrix))
+        self.assertTrue(isinstance(out, np.ndarray))
         out = rotating_frame.state_out_of_frame(t, y)
-        self.assertTrue(isinstance(out, csr_matrix))
+        self.assertTrue(isinstance(out, np.ndarray))
 
     def test_state_transformations_no_frame_Operator_types(self):
         """Test frame transformations with no frame."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As pointed out in #353 , the handling of the qutip `Qobj` type by `DYNAMICS_NUMPY.asarray` was broken with the release of qutip 5.0.0. In the past, qutip `Qobj` instances always contained customized `csr_matrix` instances, so we would always consume them by explicitly converting them to a `csr_matrix`. Qutip 5.0.0 adds a "data layer" abstraction, allowing `Qobj` instances to store different underlying array types (e.g. dense `np.ndarray`). This data layer has been written to be extensible, and hence moving forward we have no guarantees on the type of array data within a `Qobj`.

As a result of this, I've changed `DYNAMICS_NUMPY.asarray(qobj)` to return `qobj.full()`, which returns a dense `np.ndarray`. This works regardless of underlying array type, so seems like a safe future-proof way of solving this issue.

### Details and comments

I've also added an upgrade note outlining this change.
